### PR TITLE
fix squircle avatars in boost carousel

### DIFF
--- a/src/components/avatar.css
+++ b/src/components/avatar.css
@@ -13,7 +13,7 @@
   border-radius: 0;
 }
 .avatar:not(.has-alpha).squircle {
-  border-radius: 12px;
+  border-radius: 25%;
 }
 
 .avatar img {


### PR DESCRIPTION
12px border-radius made bot avatar icons round in boost carousel. 25% radius retains original shape in regular timeline and produces similar shape in the carousel.