### PR TITLE
Use optically correct media radius size

### DIFF
--- a/src/components/status.css
+++ b/src/components/status.css
@@ -573,7 +573,7 @@
   max-height: 60vh;
 }
 .status .media-container .media {
-  --media-radius: 16px;
+  --media-radius: 8px;
   border-radius: var(--media-radius);
   overflow: hidden;
   min-height: 80px;


### PR DESCRIPTION
This is mostly visible with posts with 2 or more images, since they stretch all the way to the right edge of the post card. This PR makes is so that the gap between the media and the card's border is equal all the way (in the images, you can see the before has a larger gap in the corner vs the sides).

Before/After:

<img src="https://github.com/cheeaun/phanpy/assets/43153657/a5dad012-1dd5-41db-9d34-7e2afca42eb3" alt="Second Image" width="49%">
<img src="https://github.com/cheeaun/phanpy/assets/43153657/052a776b-f62e-46f7-9e7c-9489c8003883" alt="First Image" width="49%">
