### PR TITLE
fixed: was not displaying RTL scripts properly

### DIFF
--- a/src/components/status.jsx
+++ b/src/components/status.jsx
@@ -514,6 +514,9 @@ function Status({
       (l) => language === l || localeMatch([language], [l]),
     );
 
+  const rtlLanguages = ["ar","fa","he","dv"];
+  const textDirection = rtlLanguages.includes(language) ? "rtl" : "auto";
+
   const menuInstanceRef = useRef();
   const StatusMenuItems = (
     <>
@@ -1047,7 +1050,7 @@ function Status({
               <div
                 class="content"
                 lang={language}
-                dir="auto"
+                dir={textDirection}
                 ref={spoilerContentRef}
                 data-read-more={readMoreText}
               >
@@ -1076,7 +1079,7 @@ function Status({
           <div
             class="content"
             lang={language}
-            dir="auto"
+            dir={textDirection}
             ref={contentRef}
             data-read-more={readMoreText}
           >


### PR DESCRIPTION
Added minimal support for right-to-left scripts (like arabic and hebrew) which were not displaying properly (sometimes illegible). 
Now, if the status is (tagged as) written in one of the 4 supported RTL scripts the included `dir` prop is set to `rtl` instead of `auto`. 

This is how it displays without RTL support. Notice the question mark over the red dot which should display after the word "mastodon"

![Wrong](https://github.com/cheeaun/phanpy/assets/1479/6d6e4fc8-7541-4cd6-8beb-316010836921)

This is how it will display after the patch (correct display)

![Right](https://github.com/cheeaun/phanpy/assets/1479/7af0ace4-053a-4534-adb6-9d5be0449ac0)
