### PR TITLE
Remote media: avoid never-ending loops if it won't work

### DIFF
--- a/src/components/media.jsx
+++ b/src/components/media.jsx
@@ -274,7 +274,7 @@ function Media({
                 }}
                 onError={(e) => {
                   const { src } = e.target;
-                  if (src === mediaURL) {
+                  if (src === mediaURL && mediaURL !== remoteMediaURL) {
                     e.target.src = remoteMediaURL;
                   }
                 }}
@@ -307,7 +307,7 @@ function Media({
                 }}
                 onError={(e) => {
                   const { src } = e.target;
-                  if (src === mediaURL) {
+                  if (src === mediaURL && mediaURL !== remoteMediaURL) {
                     e.target.src = remoteMediaURL;
                   }
                 }}


### PR DESCRIPTION
I've sent a PDF as an attachment to a Status, and phanpy tries to load it, but inside an <img> tag because that's the "default type". That fails.

In case of error, the code tries to change the url but it turns out to be exactly the same, so it tries again, and fails, and tries again, ad vitam eternam as fast as possible. This burns my CPU and even makes some calls to the same origin fail; the only recourse is to fresh-reload the app.

Non-image types don't seem to have this issue because there's no "retry with another url"

This little change makes sure we don't retry if it failed