### PR TITLE
Don't highlight mention when it's prepended by a dot

### DIFF
--- a/src/components/compose.jsx
+++ b/src/components/compose.jsx
@@ -108,7 +108,7 @@ function countableText(inputText) {
 // https://github.com/mastodon/mastodon/blob/c03bd2a238741a012aa4b98dc4902d6cf948ab63/app/models/account.rb#L69
 const USERNAME_RE = /[a-z0-9_]+([a-z0-9_.-]+[a-z0-9_]+)?/i;
 const MENTION_RE = new RegExp(
-  `(^|[^=\\/\\w])(@${USERNAME_RE.source}(?:@[\\p{L}\\w.-]+[\\w]+)?)`,
+  `(^|[^=\\/\\w.])(@${USERNAME_RE.source}(?:@[\\p{L}\\w.-]+[\\w]+)?)`,
   'uig',
 );
 


### PR DESCRIPTION
There is/was a convention that prepending a dot (.) before the @ makes the target user not mentioned. This is useful when you're using DMs for example and you want to talk about a third-party but don't want the third-party to get the message: putting the dot before doesn't send it to them.