### PR TITLE
Add another self-hosted instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ These are self-hosted by other wonderful folks.
 - [phanpy.blaede.family](https://phanpy.blaede.family/) by [@cassidy@blaede.family](https://mastodon.blaede.family/@cassidy)
 - [phanpy.mstdn.mx](https://phanpy.mstdn.mx/) by [@maop@mstdn.mx](https://mstdn.mx/@maop)
 - [phanpy.vmst.io](https://phanpy.vmst.io/) by [@vmstan@vmst.io](https://vmst.io/@vmstan)
+- [phanpy.gotosocial.social](https://phanpy.gotosocial.social/) by [@admin@gotosocial.social](https://gotosocial.social/@admin)
 
 > Note: Add yours by creating a pull request.
 


### PR DESCRIPTION
This PR adds a self-hosted phanpy deployment:
- **Domain**: `phanpy.gotosocial.social`
- **Contact account**: `@admin@gotosocial.social`
- **Service provider**: Cloudflare Pages
- I'll keep this deployment up to date with the upstream repository.
