### PR TITLE
[Hotfix] Infinite loop bug in intersection observer

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -86,7 +86,7 @@ a[href^='http'][rel*='nofollow']:visited:not(:has(div)) {
   inset: 0;
 }
 :is(#home-page, #welcome, #columns, #loader-root):has(~ .deck-container) {
-  display: block;
+  /* display: block; */
   position: absolute;
   user-select: none;
   pointer-events: none;


### PR DESCRIPTION
When columns mode enabled, going to other pages will hide the columns, via this CSS:

```
#columns:has(~ .deck-container) {
  display: block;
  …
}
```

The display block rearranges the layout thus causing `<InView/>` component to trigger, causing infinite loop in its intersection observer, constantly loading the timeline.