### PR TITLE
Update README.md to add hear-me.social

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ These are self-hosted by other wonderful folks.
 - [phanpy.vmst.io](https://phanpy.vmst.io/) by [@vmstan@vmst.io](https://vmst.io/@vmstan)
 - [phanpy.gotosocial.social](https://phanpy.gotosocial.social/) by [@admin@gotosocial.social](https://gotosocial.social/@admin)
 - [phanpy.bauxite.tech](https://phanpy.bauxite.tech) by [@b4ux1t3@hachyderm.io](https://hachyderm.io/@b4ux1t3)
+- [phanpy.hear-me.social](https://phanpy.hear-me.social) by [@admin@hear-me.social](https://hear-me.social/@admin)
 
 > Note: Add yours by creating a pull request.
 


### PR DESCRIPTION
Added phanpy.hear-me.social to the list of deployed sites in README.md

    Domain: phanpy.hear-me.social
    Contact account: @admin@hear-me.social
    I'll keep the deployment up-to-date with the upstream repo

