### PR TITLE
Add another phanpy instance url

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ These are self-hosted by other wonderful folks.
 - [phanpy.gotosocial.social](https://phanpy.gotosocial.social/) by [@admin@gotosocial.social](https://gotosocial.social/@admin)
 - [phanpy.bauxite.tech](https://phanpy.bauxite.tech) by [@b4ux1t3@hachyderm.io](https://hachyderm.io/@b4ux1t3)
 - [phanpy.hear-me.social](https://phanpy.hear-me.social) by [@admin@hear-me.social](https://hear-me.social/@admin)
+- [phanpy.fulda.social](https://phanpy.fulda.social) by [@Ganneff@fulda.social](https://fulda.social/@Ganneff)
 
 > Note: Add yours by creating a pull request.
 


### PR DESCRIPTION
Adding fulda.social to the list of self-hosted instances.