### PR TITLE
(performance) Remove backdrop-filter blur and saturate effect from .account-sub-icons

### DIFF
--- a/src/pages/notifications.css
+++ b/src/pages/notifications.css
@@ -63,7 +63,6 @@
     var(--bg-color),
     var(--bg-blur-color)
   ); */
-  backdrop-filter: blur(16px) saturate(3);
   padding: 2px 4px;
   border-radius: 999px;
   overflow: hidden;


### PR DESCRIPTION
Using Firefox for Android on a low-end phone, I notice that my notifications screen is very slow to scroll when I have 10+ notifications on one post.

When I remove this backdrop-filter style, the problem goes away - eyeball estimate is that scrolling gets 5x faster.

Edit: This resolves issue #416 .