### PR TITLE
(performance) Remove backdrop-filter blur and saturate effects from modals

### DIFF
--- a/src/components/modal.css
+++ b/src/components/modal.css
@@ -9,7 +9,6 @@
   justify-content: center;
   align-items: center;
   background-color: var(--backdrop-color);
-  backdrop-filter: blur(24px);
   animation: appear 0.5s var(--timing-function) both;
 }
 #modal-container > div .sheet {
@@ -18,8 +17,4 @@
 }
 #modal-container > div:has(~ div) .sheet {
   transform: scale(0.975);
-}
-
-#modal-container > .light {
-  backdrop-filter: saturate(0.75);
 }


### PR DESCRIPTION
Using Firefox for Android on a low-end phone, when I check who interacted with a post and view someone's account, in the modal, it is _extremely_ slow to scroll - 500ms+ latency for scroll to start, and renders at ~5 FPS while scrolling.

For clarity, here is the screen I am referring to:

![image](https://github.com/cheeaun/phanpy/assets/90956290/59a1da05-4fbb-44d9-9f2e-0f9cb0b5b5f3)

Most of this is due to the issue described in #430, and that diff greatly improves performance for this case as well. However, scrolling is still somewhat slow. Removing these backdrop-filter effects makes the scrolling significantly faster.

Testing on Firefox (desktop and mobile) and Chrome (desktop), I cannot notice a visual difference with and without the removed styles. I only tested this specific screen, and there are lots of other modals, so it may have made a visual difference elsewhere.