### PR TITLE
Remove `/X` indicator from threads 

### DIFF
--- a/src/components/status.jsx
+++ b/src/components/status.jsx
@@ -1620,7 +1620,7 @@ function Status({
                   <Icon icon="thread" size="s" />
                   Thread
                   {snapStates.statusThreadNumber[sKey]
-                    ? ` ${snapStates.statusThreadNumber[sKey]}/X`
+                    ? ` ${snapStates.statusThreadNumber[sKey]}`
                     : ''}
                 </div>
               ) : (


### PR DESCRIPTION
This PR removes the `/X` in the status component, as `/X` was a placeholder, and never displayed the total thread count. If we *did* display the thread total thread count, then, depending on the thread count, would make a lot of requests to the instance's API. In the way this PR does it, it just displays the current thread count, for example, `THREAD 1`, `THREAD 2`, etc.

## Screenshots
![image](https://github.com/cheeaun/phanpy/assets/67456566/c391a5c2-3de7-4d3d-b277-b4632e74de2c)
