### PR TITLE
add tldr.nettime.org to instances list

### DIFF
--- a/src/data/instances.json
+++ b/src/data/instances.json
@@ -380,5 +380,6 @@
 	"learningdisability.social",
 	"mastodon.bida.im",
 	"computerfairi.es",
-	"tea.codes"
+	"tea.codes",
+	"tldr.nettime.org"
 ]


### PR DESCRIPTION
Adding https://tldr.nettime.org/ to the server list. This is the Mastodon instance of the nettime.org mailing list / community.