### PR TITLE
Enable running using http

### DIFF
--- a/src/pages/login.jsx
+++ b/src/pages/login.jsx
@@ -12,7 +12,7 @@ import { getAuthorizationURL, registerApplication } from '../utils/auth';
 import store from '../utils/store';
 import useTitle from '../utils/useTitle';
 
-const { PHANPY_DEFAULT_INSTANCE: DEFAULT_INSTANCE } = import.meta.env;
+const { PHANPY_DEFAULT_INSTANCE: DEFAULT_INSTANCE, PHANPY_SCHEME: SCHEME = 'https' } = import.meta.env;
 
 function Login() {
   useTitle('Log in');
@@ -85,9 +85,11 @@ function Login() {
         .replace(/^@?[^@]+@/, '') // Remove @?acct@
         .trim()
     : null;
-  const instanceTextLooksLikeDomain =
-    /[^\s\r\n\t\/\\]+\.[^\s\r\n\t\/\\]+/.test(cleanInstanceText) &&
-    !/[\s\/\\@]/.test(cleanInstanceText);
+  const instanceTextLooksLikeDomain = 
+    (/[^\s\r\n\t\/\\]+\.[^\s\r\n\t\/\\]+/.test(cleanInstanceText) &&
+    !/[\s\/\\@]/.test(cleanInstanceText)) || SCHEME === "http";
+
+  console.log(SCHEME)
 
   const instancesSuggestions = cleanInstanceText
     ? instancesList

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -9,6 +9,8 @@ import {
   saveAccount,
 } from './store-utils';
 
+const { PHANPY_SCHEME: SCHEME = 'https' } = import.meta.env;
+
 // Default *fallback* instance
 const DEFAULT_INSTANCE = 'mastodon.social';
 
@@ -36,7 +38,9 @@ export function initClient({ instance, accessToken }) {
       .replace(/\/+$/, '')
       .toLowerCase();
   }
-  const url = instance ? `https://${instance}` : `https://${DEFAULT_INSTANCE}`;
+  const url = instance
+    ? `${SCHEME}://${instance}`
+    : `${SCHEME}://${DEFAULT_INSTANCE}`;
 
   const masto = createRestAPIClient({
     url,

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,5 +1,8 @@
-const { PHANPY_CLIENT_NAME: CLIENT_NAME, PHANPY_WEBSITE: WEBSITE } = import.meta
-  .env;
+const {
+  PHANPY_CLIENT_NAME: CLIENT_NAME,
+  PHANPY_WEBSITE: WEBSITE,
+  PHANPY_SCHEME: SCHEME = 'https',
+} = import.meta.env;
 
 const SCOPES = 'read write follow push';
 
@@ -11,7 +14,7 @@ export async function registerApplication({ instanceURL }) {
     website: WEBSITE,
   });
   const registrationResponse = await fetch(
-    `https://${instanceURL}/api/v1/apps`,
+    `${SCHEME}://${instanceURL}/api/v1/apps`,
     {
       method: 'POST',
       headers: {
@@ -33,7 +36,7 @@ export async function getAuthorizationURL({ instanceURL, client_id }) {
     // redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
     response_type: 'code',
   });
-  const authorizationURL = `https://${instanceURL}/oauth/authorize?${authorizationParams.toString()}`;
+  const authorizationURL = `${SCHEME}://${instanceURL}/oauth/authorize?${authorizationParams.toString()}`;
   return authorizationURL;
 }
 
@@ -51,7 +54,7 @@ export async function getAccessToken({
     code,
     scope: SCOPES,
   });
-  const tokenResponse = await fetch(`https://${instanceURL}/oauth/token`, {
+  const tokenResponse = await fetch(`${SCHEME}://${instanceURL}/oauth/token`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',


### PR DESCRIPTION
This means that by adding PHANPY_SCHEME=http to the file ".env" phanpy will use http instead of https to connect to remote instances.

This is useful to test local versions of various Fediverse applications. These can be created following the instructions on

https://funfedi.dev/quickstart/#running-an-application-from-the-fediverse-pasture