### PR TITLE
Fix `enter` keyboard shortcut on timeline

### DIFF
--- a/src/components/timeline.jsx
+++ b/src/components/timeline.jsx
@@ -209,8 +209,8 @@ function Timeline({
 
   const oRef = useHotkeys(['enter', 'o'], () => {
     // open active status
-    const activeItem = document.activeElement.closest(itemsSelector);
-    if (activeItem) {
+    const activeItem = document.activeElement;
+    if (activeItem?.matches(itemsSelector)) {
       activeItem.click();
     }
   });


### PR DESCRIPTION
Currently pressing `enter` opens the active status if the status _or_ any focusable child of the status is focused e.g. the avatar or a link. I think it should only open the post details when the post itself is focused.

Current behaviour (pressing enter when username focused opens post):
[enter_on_username_opens_post.webm](https://github.com/cheeaun/phanpy/assets/582896/b48ccccc-9a00-4c51-a128-74bade8548fc)

New behaviour (pressing enter when username focused opens profile):
[enter_on_username_opens_profile.webm](https://github.com/cheeaun/phanpy/assets/582896/0cde81fe-5bfe-41b8-b3d2-1075e248ec3b)


