### PR TITLE
fix: enable/disable boosts button logic

### DIFF
--- a/src/components/account-info.jsx
+++ b/src/components/account-info.jsx
@@ -1159,8 +1159,8 @@ function RelatedActions({
                             setRelationshipUIState('default');
                             showToast(
                               rel.showingReblogs
-                                ? `Boosts from @${username} disabled.`
-                                : `Boosts from @${username} enabled.`,
+                                ? `Boosts from @${username} enabled.`
+                                : `Boosts from @${username} disabled.`,
                             );
                           } catch (e) {
                             alert(e);


### PR DESCRIPTION
Currently, if you click the "Disable boosts" button, the toast would say "Boosts from user enabled." or click the "Enable boosts" button, it would say "Boosts from user disabled." 

This should be caused by a logic mistake and this PR fixes it.