### PR TITLE
Fix overflow for the columns wrapper

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -2419,7 +2419,7 @@ ul.link-list li a .icon {
   display: flex;
   width: 100vw;
   overflow-y: hidden;
-  overflow-x: scroll;
+  overflow-x: auto;
   scroll-snap-type: x mandatory;
   scroll-behavior: smooth;
   /* scrollbar-width: none; */


### PR DESCRIPTION
When an OS does not have “overlay” scrollbars, the `scroll` values of `overflow` lead to the empty scrollbars visible ([more details](https://blog.kizu.dev/never-use-overflow-scroll/)).

In the case of Phanpy, in its multicolumn view, this scrollbar eats from the available vertical space.