### PR TITLE
Filter out languages that aren't RFC5646-shaped

### DIFF
--- a/src/utils/localeCode2Text.jsx
+++ b/src/utils/localeCode2Text.jsx
@@ -1,6 +1,6 @@
 import mem from './mem';
 
-const IntlDN = new Intl.DisplayNames(navigator.languages, {
+const IntlDN = new Intl.DisplayNames(undefined, {
   type: 'language',
 });
 


### PR DESCRIPTION
I wanted to try Phanpy, but only got a blank page, because `Intl.DisplayNames` can't handle some values that might appear in `navigator.languages`.

[As MDN says](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/languages):

> The [Accept-Language](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language) HTTP header in every HTTP request from the user's browser generally lists the same locales as the navigator.languages property, with decreasing q values (quality values).

My config includes `*;q=0.5` as the last value, which gives a `navigator.languages` like `['xx', 'xx', 'xx', 'xx', '*']`.

```js
new Intl.DisplayNames([..., '*'], {
    type: 'language'
})
```
results in `RangeError: Incorrect locale information provided`.

So this proposed fix filters out any language tags that don't look like RFC 5646/BCP 47 format, [which is what `Intl.DisplayNames` accepts](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames/DisplayNames#locales).

It's not a full validator, but it does not exclude any valid tags.