### PR TITLE
Configure linguist overrides for this repository

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.po linguist-generated
+readme-assets/** linguist-documentation

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.po linguist-generated


### PR DESCRIPTION
GitHub uses [Linguist](https://github.com/github-linguist/linguist) for various features in repository pages, from displaying pull requests to calculating repository stats.

Sometimes, Linguist can use an hint in understanding how the project is structured, and that's done via [overrides](https://github.com/github-linguist/linguist/blob/master/docs/overrides.md).

With this PR:
- `*.po` files are marked as `generated`, which means they start collapsed by default in pull requests like binary files and aren't counted in language stats;
- anything in `readme-assets/**` is marked as `documentation`, which for now only excludes the directory from language stats.

I think that this would make PRs easier to examine at a glance, as the significant content is highlighted, while not stopping anyone from inspecting the contents of the changed *.po files, as they're just a click away from being opened.