### PR TITLE
Fix invalid vote counts on single choice polls on certain MastoAPI implementations

### DIFF
--- a/src/components/poll.jsx
+++ b/src/components/poll.jsx
@@ -49,7 +49,7 @@ export default function Poll({
   //   };
   // }, [expired, expiresAtDate]);
 
-  const pollVotesCount = votersCount || votesCount;
+  const pollVotesCount = multiple ? votersCount : votesCount;
   let roundPrecision = 0;
 
   if (pollVotesCount <= 1000) {


### PR DESCRIPTION
Fixes #510.

---

[Your intuition](https://github.com/cheeaun/phanpy/issues/510#issuecomment-2066816279) was correct: that was the issue.

Sadly, a patch doesn't seem to have been merged upstream yet, so in the meantime, it seems to me that a better idea for handling multiple choice polls both on https://github.com/cheeaun/phanpy/labels/akkoma and the Mastodon API might be this.