### PR TITLE
Hide trending where not supported and update compatibility table

### DIFF
--- a/src/components/nav-menu.jsx
+++ b/src/components/nav-menu.jsx
@@ -374,14 +374,12 @@ function NavMenu(props) {
               <Trans>Search</Trans>
             </span>
           </MenuLink>
-          {(supports("@mastodon/trending-hashtags") || supports("@mastodon/trending-links") || supports("@pixelfed/trending")) &&
-            <MenuLink to={`/${instance}/trending`}>
-              <Icon icon="chart" size="l" />{' '}
-              <span>
-                <Trans>Trending</Trans>
-              </span>
-            </MenuLink>
-          }
+          <MenuLink to={`/${instance}/trending`}>
+            <Icon icon="chart" size="l" />{' '}
+            <span>
+              <Trans>Trending</Trans>
+            </span>
+          </MenuLink>
           <MenuLink to={`/${instance}/p/l`}>
             <Icon icon="building" size="l" />{' '}
             <span>

--- a/src/components/nav-menu.jsx
+++ b/src/components/nav-menu.jsx
@@ -374,12 +374,14 @@ function NavMenu(props) {
               <Trans>Search</Trans>
             </span>
           </MenuLink>
-          <MenuLink to={`/${instance}/trending`}>
-            <Icon icon="chart" size="l" />{' '}
-            <span>
-              <Trans>Trending</Trans>
-            </span>
-          </MenuLink>
+          {(supports("@mastodon/trending-hashtags") || supports("@mastodon/trending-links") || supports("@pixelfed/trending")) &&
+            <MenuLink to={`/${instance}/trending`}>
+              <Icon icon="chart" size="l" />{' '}
+              <span>
+                <Trans>Trending</Trans>
+              </span>
+            </MenuLink>
+          }
           <MenuLink to={`/${instance}/p/l`}>
             <Icon icon="building" size="l" />{' '}
             <span>

--- a/src/locales/en.po
+++ b/src/locales/en.po
@@ -621,7 +621,7 @@ msgid "Public"
 msgstr ""
 
 #: src/components/compose.jsx:1174
-#: src/components/nav-menu.jsx:386
+#: src/components/nav-menu.jsx:388
 #: src/components/shortcuts-settings.jsx:162
 #: src/components/status.jsx:94
 msgid "Local"
@@ -974,7 +974,7 @@ msgid "The end."
 msgstr ""
 
 #: src/components/keyboard-shortcuts-help.jsx:43
-#: src/components/nav-menu.jsx:405
+#: src/components/nav-menu.jsx:407
 #: src/pages/catchup.jsx:1618
 msgid "Keyboard shortcuts"
 msgstr ""
@@ -1351,24 +1351,24 @@ msgstr ""
 msgid "Log in"
 msgstr ""
 
-#: src/components/nav-menu.jsx:380
+#: src/components/nav-menu.jsx:381
 #: src/components/shortcuts-settings.jsx:57
 #: src/components/shortcuts-settings.jsx:169
 #: src/pages/trending.jsx:407
 msgid "Trending"
 msgstr ""
 
-#: src/components/nav-menu.jsx:392
+#: src/components/nav-menu.jsx:394
 #: src/components/shortcuts-settings.jsx:162
 msgid "Federated"
 msgstr ""
 
-#: src/components/nav-menu.jsx:415
+#: src/components/nav-menu.jsx:417
 msgid "Shortcuts / Columns…"
 msgstr ""
 
-#: src/components/nav-menu.jsx:425
-#: src/components/nav-menu.jsx:439
+#: src/components/nav-menu.jsx:427
+#: src/components/nav-menu.jsx:441
 msgid "Settings…"
 msgstr ""
 
@@ -2320,7 +2320,7 @@ msgstr ""
 
 #: src/components/timeline.jsx:968
 msgid "<0>Filtered</0>: <1>{0}</1>"
-msgstr ""
+msgstr "<0>Filtered</0>: <1>{0}</1>"
 
 #: src/components/translation-block.jsx:152
 msgid "Auto-translated from {sourceLangText}"

--- a/src/locales/en.po
+++ b/src/locales/en.po
@@ -621,7 +621,7 @@ msgid "Public"
 msgstr ""
 
 #: src/components/compose.jsx:1174
-#: src/components/nav-menu.jsx:388
+#: src/components/nav-menu.jsx:386
 #: src/components/shortcuts-settings.jsx:162
 #: src/components/status.jsx:94
 msgid "Local"
@@ -974,7 +974,7 @@ msgid "The end."
 msgstr ""
 
 #: src/components/keyboard-shortcuts-help.jsx:43
-#: src/components/nav-menu.jsx:407
+#: src/components/nav-menu.jsx:405
 #: src/pages/catchup.jsx:1618
 msgid "Keyboard shortcuts"
 msgstr ""
@@ -1351,24 +1351,24 @@ msgstr ""
 msgid "Log in"
 msgstr ""
 
-#: src/components/nav-menu.jsx:381
+#: src/components/nav-menu.jsx:380
 #: src/components/shortcuts-settings.jsx:57
 #: src/components/shortcuts-settings.jsx:169
 #: src/pages/trending.jsx:407
 msgid "Trending"
 msgstr ""
 
-#: src/components/nav-menu.jsx:394
+#: src/components/nav-menu.jsx:392
 #: src/components/shortcuts-settings.jsx:162
 msgid "Federated"
 msgstr ""
 
-#: src/components/nav-menu.jsx:417
+#: src/components/nav-menu.jsx:415
 msgid "Shortcuts / Columns…"
 msgstr ""
 
-#: src/components/nav-menu.jsx:427
-#: src/components/nav-menu.jsx:441
+#: src/components/nav-menu.jsx:425
+#: src/components/nav-menu.jsx:439
 msgid "Settings…"
 msgstr ""
 
@@ -3643,6 +3643,10 @@ msgstr ""
 #: src/pages/trending.jsx:414
 msgid "No trending posts."
 msgstr ""
+
+#: src/pages/trending.jsx:415
+msgid "Your server does not seem to support the Trending timeline"
+msgstr "Your server does not seem to support the Trending timeline"
 
 #: src/pages/welcome.jsx:53
 msgid "A minimalistic opinionated Mastodon web client."

--- a/src/pages/trending.jsx
+++ b/src/pages/trending.jsx
@@ -412,7 +412,7 @@ function Trending({ columnMode, ...props }) {
       id="trending"
       instance={instance}
       emptyText={t`No trending posts.`}
-      errorText={t`Unable to load posts`}
+      errorText={hasCurrentLink ? t`Unable to load posts` : t`Your server does not seem to support the Trending timeline`}
       fetchItems={hasCurrentLink ? fetchLinkMentions : fetchTrends}
       checkForUpdates={hasCurrentLink ? undefined : checkForUpdates}
       checkForUpdatesInterval={5 * 60 * 1000} // 5 minutes

--- a/src/utils/supports.js
+++ b/src/utils/supports.js
@@ -9,12 +9,13 @@ const containPixelfed = /pixelfed/i;
 const notContainPixelfed = /^(?!.*pixelfed).*$/i;
 const containPleroma = /pleroma/i;
 const containAkkoma = /akkoma/i;
+const notContainPixelfedAkkomaPleroma = /^(?!.*pixelfed|.*akkoma|.*pleroma).*$/i;
 const platformFeatures = {
   '@mastodon/lists': notContainPixelfed,
-  '@mastodon/filters': notContainPixelfed,
+  '@mastodon/filters': notContainPixelfedAkkomaPleroma,
   '@mastodon/mentions': notContainPixelfed,
-  '@mastodon/trending-hashtags': notContainPixelfed,
-  '@mastodon/trending-links': notContainPixelfed,
+  '@mastodon/trending-hashtags': notContainPixelfedAkkomaPleroma,
+  '@mastodon/trending-links': notContainPixelfedAkkomaPleroma,
   '@mastodon/post-bookmark': notContainPixelfed,
   '@mastodon/post-edit': notContainPixelfed,
   '@mastodon/profile-edit': notContainPixelfed,

--- a/src/utils/supports.js
+++ b/src/utils/supports.js
@@ -9,13 +9,12 @@ const containPixelfed = /pixelfed/i;
 const notContainPixelfed = /^(?!.*pixelfed).*$/i;
 const containPleroma = /pleroma/i;
 const containAkkoma = /akkoma/i;
-const notContainPixelfedAkkomaPleroma = /^(?!.*pixelfed|.*akkoma|.*pleroma).*$/i;
 const platformFeatures = {
   '@mastodon/lists': notContainPixelfed,
-  '@mastodon/filters': notContainPixelfedAkkomaPleroma,
+  '@mastodon/filters': (v) => !(containPixelfed.test(v) || containPleroma.test(v) || containAkkoma.test(v)),
   '@mastodon/mentions': notContainPixelfed,
-  '@mastodon/trending-hashtags': notContainPixelfedAkkomaPleroma,
-  '@mastodon/trending-links': notContainPixelfedAkkomaPleroma,
+  '@mastodon/trending-hashtags': (v) => !(containPixelfed.test(v) || containPleroma.test(v) || containAkkoma.test(v)),
+  '@mastodon/trending-links': (v) => !(containPixelfed.test(v) || containPleroma.test(v) || containAkkoma.test(v)),
   '@mastodon/post-bookmark': notContainPixelfed,
   '@mastodon/post-edit': notContainPixelfed,
   '@mastodon/profile-edit': notContainPixelfed,
@@ -33,9 +32,13 @@ function supports(feature) {
     const { version, domain } = getCurrentInstance();
     const key = `${domain}-${feature}`;
     if (supportsCache[key]) return supportsCache[key];
-
-    if (platformFeatures[feature]) {
-      return (supportsCache[key] = platformFeatures[feature].test(version));
+    
+    const platformFeature = platformFeatures[feature];
+    if (platformFeature instanceof Function) {
+      return (supportsCache[key] = platformFeature(version));
+    }
+    else if(platformFeature !== undefined) {
+      return (supportsCache[key] = platformFeature.test(version));
     }
 
     const range = features[feature];


### PR DESCRIPTION
https://github.com/cheeaun/phanpy/labels/pleroma and https://github.com/cheeaun/phanpy/labels/akkoma don't support Trending, perhaps by development philosophy.

This pull request allows hiding the option from the menu for accounts on such instances, and additionally does the same with the Filter option.