### PR TITLE
Fix editing image descriptions

### DIFF
--- a/src/components/compose.jsx
+++ b/src/components/compose.jsx
@@ -1244,7 +1244,10 @@ function Compose({
                     onDescriptionChange={(value) => {
                       setMediaAttachments((attachments) => {
                         const newAttachments = [...attachments];
-                        newAttachments[i].description = value;
+                        newAttachments[i] = {
+                          ...newAttachments[i],
+                          description: value,
+                        };
                         return newAttachments;
                       });
                     }}

--- a/src/locales/en.po
+++ b/src/locales/en.po
@@ -105,7 +105,7 @@ msgstr ""
 
 #: src/components/account-info.jsx:427
 #: src/components/account-info.jsx:1115
-#: src/components/compose.jsx:2456
+#: src/components/compose.jsx:2459
 #: src/components/media-alt-modal.jsx:45
 #: src/components/media-modal.jsx:283
 #: src/components/status.jsx:1636
@@ -401,10 +401,10 @@ msgstr ""
 #: src/components/account-info.jsx:2089
 #: src/components/account-sheet.jsx:37
 #: src/components/compose.jsx:797
-#: src/components/compose.jsx:2412
-#: src/components/compose.jsx:2885
-#: src/components/compose.jsx:3093
-#: src/components/compose.jsx:3323
+#: src/components/compose.jsx:2415
+#: src/components/compose.jsx:2888
+#: src/components/compose.jsx:3096
+#: src/components/compose.jsx:3326
 #: src/components/drafts.jsx:58
 #: src/components/embed-modal.jsx:12
 #: src/components/generic-accounts.jsx:142
@@ -547,8 +547,8 @@ msgstr ""
 
 #: src/components/compose.jsx:614
 #: src/components/compose.jsx:630
-#: src/components/compose.jsx:1333
-#: src/components/compose.jsx:1594
+#: src/components/compose.jsx:1336
+#: src/components/compose.jsx:1597
 msgid "{maxMediaAttachments, plural, one {You can only attach up to 1 file.} other {You can only attach up to # files.}}"
 msgstr ""
 
@@ -657,19 +657,19 @@ msgstr ""
 msgid "What are you doing?"
 msgstr ""
 
-#: src/components/compose.jsx:1271
+#: src/components/compose.jsx:1274
 msgid "Mark media as sensitive"
 msgstr ""
 
-#: src/components/compose.jsx:1369
+#: src/components/compose.jsx:1372
 msgid "Add poll"
 msgstr ""
 
-#: src/components/compose.jsx:1391
+#: src/components/compose.jsx:1394
 msgid "Add custom emoji"
 msgstr ""
 
-#: src/components/compose.jsx:1475
+#: src/components/compose.jsx:1478
 #: src/components/keyboard-shortcuts-help.jsx:143
 #: src/components/status.jsx:831
 #: src/components/status.jsx:1616
@@ -678,195 +678,195 @@ msgstr ""
 msgid "Reply"
 msgstr ""
 
-#: src/components/compose.jsx:1477
+#: src/components/compose.jsx:1480
 msgid "Update"
 msgstr ""
 
-#: src/components/compose.jsx:1478
+#: src/components/compose.jsx:1481
 msgctxt "Submit button in composer"
 msgid "Post"
 msgstr ""
 
-#: src/components/compose.jsx:1606
+#: src/components/compose.jsx:1609
 msgid "Downloading GIF…"
 msgstr ""
 
-#: src/components/compose.jsx:1634
+#: src/components/compose.jsx:1637
 msgid "Failed to download GIF"
 msgstr ""
 
-#: src/components/compose.jsx:1745
-#: src/components/compose.jsx:1822
+#: src/components/compose.jsx:1748
+#: src/components/compose.jsx:1825
 #: src/components/nav-menu.jsx:287
 msgid "More…"
 msgstr ""
 
-#: src/components/compose.jsx:2225
+#: src/components/compose.jsx:2228
 msgid "Uploaded"
 msgstr ""
 
-#: src/components/compose.jsx:2238
+#: src/components/compose.jsx:2241
 msgid "Image description"
 msgstr ""
 
-#: src/components/compose.jsx:2239
+#: src/components/compose.jsx:2242
 msgid "Video description"
 msgstr ""
 
-#: src/components/compose.jsx:2240
+#: src/components/compose.jsx:2243
 msgid "Audio description"
 msgstr ""
 
-#: src/components/compose.jsx:2276
-#: src/components/compose.jsx:2296
+#: src/components/compose.jsx:2279
+#: src/components/compose.jsx:2299
 msgid "File size too large. Uploading might encounter issues. Try reduce the file size from {0} to {1} or lower."
 msgstr ""
 
-#: src/components/compose.jsx:2288
-#: src/components/compose.jsx:2308
+#: src/components/compose.jsx:2291
+#: src/components/compose.jsx:2311
 msgid "Dimension too large. Uploading might encounter issues. Try reduce dimension from {0}×{1}px to {2}×{3}px."
 msgstr ""
 
-#: src/components/compose.jsx:2316
+#: src/components/compose.jsx:2319
 msgid "Frame rate too high. Uploading might encounter issues."
 msgstr ""
 
-#: src/components/compose.jsx:2376
-#: src/components/compose.jsx:2626
+#: src/components/compose.jsx:2379
+#: src/components/compose.jsx:2629
 #: src/components/shortcuts-settings.jsx:723
 #: src/pages/catchup.jsx:1074
 #: src/pages/filters.jsx:412
 msgid "Remove"
 msgstr ""
 
-#: src/components/compose.jsx:2393
+#: src/components/compose.jsx:2396
 #: src/compose.jsx:83
 msgid "Error"
 msgstr ""
 
-#: src/components/compose.jsx:2418
+#: src/components/compose.jsx:2421
 msgid "Edit image description"
 msgstr ""
 
-#: src/components/compose.jsx:2419
+#: src/components/compose.jsx:2422
 msgid "Edit video description"
 msgstr ""
 
-#: src/components/compose.jsx:2420
+#: src/components/compose.jsx:2423
 msgid "Edit audio description"
 msgstr ""
 
-#: src/components/compose.jsx:2465
-#: src/components/compose.jsx:2514
+#: src/components/compose.jsx:2468
+#: src/components/compose.jsx:2517
 msgid "Generating description. Please wait…"
 msgstr ""
 
-#: src/components/compose.jsx:2485
+#: src/components/compose.jsx:2488
 msgid "Failed to generate description: {0}"
 msgstr ""
 
-#: src/components/compose.jsx:2486
+#: src/components/compose.jsx:2489
 msgid "Failed to generate description"
 msgstr ""
 
-#: src/components/compose.jsx:2498
-#: src/components/compose.jsx:2504
-#: src/components/compose.jsx:2550
+#: src/components/compose.jsx:2501
+#: src/components/compose.jsx:2507
+#: src/components/compose.jsx:2553
 msgid "Generate description…"
 msgstr ""
 
-#: src/components/compose.jsx:2537
+#: src/components/compose.jsx:2540
 msgid "Failed to generate description{0}"
 msgstr ""
 
-#: src/components/compose.jsx:2552
+#: src/components/compose.jsx:2555
 msgid "({0}) <0>— experimental</0>"
 msgstr ""
 
-#: src/components/compose.jsx:2571
+#: src/components/compose.jsx:2574
 msgid "Done"
 msgstr ""
 
-#: src/components/compose.jsx:2607
+#: src/components/compose.jsx:2610
 msgid "Choice {0}"
 msgstr ""
 
-#: src/components/compose.jsx:2654
+#: src/components/compose.jsx:2657
 msgid "Multiple choices"
 msgstr ""
 
-#: src/components/compose.jsx:2657
+#: src/components/compose.jsx:2660
 msgid "Duration"
 msgstr ""
 
-#: src/components/compose.jsx:2688
+#: src/components/compose.jsx:2691
 msgid "Remove poll"
 msgstr ""
 
-#: src/components/compose.jsx:2902
+#: src/components/compose.jsx:2905
 msgid "Search accounts"
 msgstr ""
 
-#: src/components/compose.jsx:2943
+#: src/components/compose.jsx:2946
 #: src/components/shortcuts-settings.jsx:712
 #: src/pages/list.jsx:359
 msgid "Add"
 msgstr ""
 
-#: src/components/compose.jsx:2956
+#: src/components/compose.jsx:2959
 #: src/components/generic-accounts.jsx:227
 msgid "Error loading accounts"
 msgstr ""
 
-#: src/components/compose.jsx:3099
+#: src/components/compose.jsx:3102
 msgid "Custom emojis"
 msgstr ""
 
-#: src/components/compose.jsx:3119
+#: src/components/compose.jsx:3122
 msgid "Search emoji"
 msgstr ""
 
-#: src/components/compose.jsx:3150
+#: src/components/compose.jsx:3153
 msgid "Error loading custom emojis"
 msgstr ""
 
-#: src/components/compose.jsx:3161
+#: src/components/compose.jsx:3164
 msgid "Recently used"
 msgstr ""
 
-#: src/components/compose.jsx:3162
+#: src/components/compose.jsx:3165
 msgid "Others"
 msgstr ""
 
-#: src/components/compose.jsx:3200
+#: src/components/compose.jsx:3203
 msgid "{0} more…"
 msgstr ""
 
-#: src/components/compose.jsx:3338
+#: src/components/compose.jsx:3341
 msgid "Search GIFs"
 msgstr ""
 
-#: src/components/compose.jsx:3353
+#: src/components/compose.jsx:3356
 msgid "Powered by GIPHY"
 msgstr ""
 
-#: src/components/compose.jsx:3361
+#: src/components/compose.jsx:3364
 msgid "Type to search GIFs"
 msgstr ""
 
-#: src/components/compose.jsx:3459
+#: src/components/compose.jsx:3462
 #: src/components/media-modal.jsx:387
 #: src/components/timeline.jsx:889
 msgid "Previous"
 msgstr ""
 
-#: src/components/compose.jsx:3477
+#: src/components/compose.jsx:3480
 #: src/components/media-modal.jsx:406
 #: src/components/timeline.jsx:906
 msgid "Next"
 msgstr ""
 
-#: src/components/compose.jsx:3494
+#: src/components/compose.jsx:3497
 msgid "Error loading GIFs"
 msgstr ""
 


### PR DESCRIPTION
Fixes #778.

When editing a status, the `description` property on each attachment is read-only, so modifying it directly throws a `TypeError`.