### PR TITLE
Ignore vite temporary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ phanpy-dist.tar.gz
 
 # Compiled locale files
 src/locales/*.js
+vite.config.js.timestamp-*.mjs


### PR DESCRIPTION
Vite sometimes seem to leave some files in the project root directory.

This patch adds them to the .gitignore.