### PR TITLE
Initial support for Unicode emojis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@szhsin/react-menu": "~4.2.3",
         "chroma-js": "~3.1.2",
         "compare-versions": "~6.1.1",
+        "emojibase-data": "^15.3.2",
         "fast-blurhash": "~1.1.4",
         "fast-equals": "~5.0.1",
         "fuse.js": "~7.0.0",
@@ -5537,6 +5538,28 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "node_modules/emojibase": {
+      "version": "15.3.1",
+      "resolved": "https://registry.npmjs.org/emojibase/-/emojibase-15.3.1.tgz",
+      "integrity": "sha512-GNsjHnG2J3Ktg684Fs/vZR/6XpOSkZPMAv85EHrr6br2RN2cJNwdS4am/3YSK3y+/gOv2kmoK3GGdahXdMxg2g==",
+      "peer": true,
+      "funding": {
+        "type": "ko-fi",
+        "url": "https://ko-fi.com/milesjohnson"
+      }
+    },
+    "node_modules/emojibase-data": {
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/emojibase-data/-/emojibase-data-15.3.2.tgz",
+      "integrity": "sha512-TpDyTDDTdqWIJixV5sTA6OQ0P0JfIIeK2tFRR3q56G9LK65ylAZ7z3KyBXokpvTTJ+mLUXQXbLNyVkjvnTLE+A==",
+      "funding": {
+        "type": "ko-fi",
+        "url": "https://ko-fi.com/milesjohnson"
+      },
+      "peerDependencies": {
+        "emojibase": "*"
+      }
     },
     "node_modules/entities": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@szhsin/react-menu": "~4.2.3",
     "chroma-js": "~3.1.2",
     "compare-versions": "~6.1.1",
+    "emojibase-data": "^15.3.2",
     "fast-blurhash": "~1.1.4",
     "fast-equals": "~5.0.1",
     "fuse.js": "~7.0.0",

--- a/src/components/compose.jsx
+++ b/src/components/compose.jsx
@@ -1786,11 +1786,20 @@ function autoResizeTextarea(textarea) {
   }
 }
 
-async function _getCustomEmojis(instance, masto) {
-  const emojis = await masto.v1.customEmojis.list();
-  const visibleEmojis = emojis.filter((e) => e.visibleInPicker);
+async function _getCustomEmojis(lang, instance, masto) {
+  const [unicodeEmojis, customEmojis] = await Promise.all([
+    fetch(`./assets/emojis/${lang}.json`).then((r) => r.json()),
+    masto.v1.customEmojis.list()
+  ]);
+
+  for (let emoji of unicodeEmojis.emojis)
+    if (emoji.group in unicodeEmojis.groups)
+      emoji.category = unicodeEmojis.groups[emoji.group].message;
+
+  const visibleEmojis = customEmojis.filter((e) => e.visibleInPicker)
+    .concat(unicodeEmojis.emojis);
   const searcher = new Fuse(visibleEmojis, {
-    keys: ['shortcode'],
+    keys: ['shortcode', 'label', 'tags'],
     findAllMatches: true,
   });
   return [visibleEmojis, searcher];
@@ -1827,7 +1836,7 @@ const Textarea = forwardRef((props, ref) => {
   // const customEmojis = useRef();
   const searcherRef = useRef();
   useEffect(() => {
-    getCustomEmojis(instance, masto)
+    getCustomEmojis(i18n.locale, instance, masto)
       .then((r) => {
         const [emojis, searcher] = r;
         searcherRef.current = searcher;
@@ -1866,13 +1875,15 @@ const Textarea = forwardRef((props, ref) => {
           });
           let html = '';
           results.forEach(({ item: emoji }) => {
-            const { shortcode, url } = emoji;
+            const { unicode, shortcode, url } = emoji;
+            const presentation = unicode ? unicode :
+              `<img src="${encodeHTML(
+                url,
+              )}" width="16" height="16" alt="" loading="lazy" />`;
             html += `
-                <li role="option" data-value="${encodeHTML(shortcode)}">
-                <img src="${encodeHTML(
-                  url,
-                )}" width="16" height="16" alt="" loading="lazy" /> 
-                ${encodeHTML(shortcode)}
+              <li role="option" data-value="${encodeHTML(unicode || `:${shortcode}:`)}">
+                ${presentation}
+                ${encodeHTML(shortcode || "")}
               </li>`;
           });
           html += `<li role="option" data-value="" data-more="${text}">${t`More…`}</li>`;
@@ -1974,7 +1985,7 @@ const Textarea = forwardRef((props, ref) => {
         const { key, item } = e.detail;
         const { value, more } = item.dataset;
         if (key === ':') {
-          e.detail.value = value ? `:${value}:` : '​'; // zero-width space
+          e.detail.value = value || '​'; // zero-width space
           if (more) {
             // Prevent adding space after the above value
             e.detail.continue = true;
@@ -3115,7 +3126,7 @@ function CustomEmojisModal({
     setUIState('loading');
     (async () => {
       try {
-        const [emojis, searcher] = await getCustomEmojis(instance, masto);
+        const [emojis, searcher] = await getCustomEmojis(i18n.locale, instance, masto);
         console.log('emojis', emojis);
         searcherRef.current = searcher;
         setCustomEmojis(emojis);
@@ -3244,7 +3255,7 @@ function CustomEmojisModal({
             e.preventDefault();
             const emoji = matches[0];
             if (emoji) {
-              onSelectEmoji(`:${emoji.shortcode}:`);
+              onSelectEmoji(emoji.unicode ? emoji.unicode : `:${emoji.shortcode}:`);
             }
           }}
         >
@@ -3270,7 +3281,7 @@ function CustomEmojisModal({
                 <CustomEmojiButton
                   emoji={emoji}
                   onClick={() => {
-                    onSelectEmoji(`:${emoji.shortcode}:`);
+                    onSelectEmoji(emoji.unicode ? emoji.unicode : `:${emoji.shortcode}:`);
                   }}
                   showCode
                 />
@@ -3370,23 +3381,25 @@ const CustomEmojiButton = memo(({ emoji, onClick, showCode }) => {
       onPointerEnter={addEdges}
       onFocus={addEdges}
     >
-      <picture>
-        {!!emoji.staticUrl && (
-          <source
-            srcSet={emoji.staticUrl}
-            media="(prefers-reduced-motion: reduce)"
+      {emoji.unicode && <>{emoji.unicode}</> || (
+        <picture>
+          {!!emoji.staticUrl && (
+            <source
+              srcSet={emoji.staticUrl}
+              media="(prefers-reduced-motion: reduce)"
+            />
+          )}
+          <img
+            className="shortcode-emoji"
+            src={emoji.url || emoji.staticUrl}
+            alt={emoji.shortcode}
+            width="24"
+            height="24"
+            loading="lazy"
+            decoding="async"
           />
-        )}
-        <img
-          className="shortcode-emoji"
-          src={emoji.url || emoji.staticUrl}
-          alt={emoji.shortcode}
-          width="24"
-          height="24"
-          loading="lazy"
-          decoding="async"
-        />
-      </picture>
+        </picture>
+      )}
       {showCode && (
         <>
           {' '}

--- a/src/locales/en.po
+++ b/src/locales/en.po
@@ -104,7 +104,7 @@ msgstr ""
 
 #: src/components/account-info.jsx:429
 #: src/components/account-info.jsx:1120
-#: src/components/compose.jsx:2591
+#: src/components/compose.jsx:2602
 #: src/components/media-alt-modal.jsx:45
 #: src/components/media-modal.jsx:357
 #: src/components/status.jsx:1737
@@ -400,10 +400,10 @@ msgstr ""
 #: src/components/account-info.jsx:2094
 #: src/components/account-sheet.jsx:37
 #: src/components/compose.jsx:859
-#: src/components/compose.jsx:2547
-#: src/components/compose.jsx:3020
-#: src/components/compose.jsx:3228
-#: src/components/compose.jsx:3458
+#: src/components/compose.jsx:2558
+#: src/components/compose.jsx:3031
+#: src/components/compose.jsx:3239
+#: src/components/compose.jsx:3471
 #: src/components/drafts.jsx:58
 #: src/components/embed-modal.jsx:12
 #: src/components/generic-accounts.jsx:142
@@ -681,7 +681,7 @@ msgid "Mark media as sensitive"
 msgstr ""
 
 #: src/components/compose.jsx:1381
-#: src/components/compose.jsx:3078
+#: src/components/compose.jsx:3089
 #: src/components/shortcuts-settings.jsx:715
 #: src/pages/list.jsx:359
 msgid "Add"
@@ -713,172 +713,172 @@ msgstr ""
 msgid "Failed to download GIF"
 msgstr ""
 
-#: src/components/compose.jsx:1878
-#: src/components/compose.jsx:1955
+#: src/components/compose.jsx:1889
+#: src/components/compose.jsx:1966
 #: src/components/nav-menu.jsx:238
 msgid "More…"
 msgstr ""
 
-#: src/components/compose.jsx:2360
+#: src/components/compose.jsx:2371
 msgid "Uploaded"
 msgstr ""
 
-#: src/components/compose.jsx:2373
+#: src/components/compose.jsx:2384
 msgid "Image description"
 msgstr ""
 
-#: src/components/compose.jsx:2374
+#: src/components/compose.jsx:2385
 msgid "Video description"
 msgstr ""
 
-#: src/components/compose.jsx:2375
+#: src/components/compose.jsx:2386
 msgid "Audio description"
 msgstr ""
 
-#: src/components/compose.jsx:2411
-#: src/components/compose.jsx:2431
+#: src/components/compose.jsx:2422
+#: src/components/compose.jsx:2442
 msgid "File size too large. Uploading might encounter issues. Try reduce the file size from {0} to {1} or lower."
 msgstr ""
 
-#: src/components/compose.jsx:2423
-#: src/components/compose.jsx:2443
+#: src/components/compose.jsx:2434
+#: src/components/compose.jsx:2454
 msgid "Dimension too large. Uploading might encounter issues. Try reduce dimension from {0}×{1}px to {2}×{3}px."
 msgstr ""
 
-#: src/components/compose.jsx:2451
+#: src/components/compose.jsx:2462
 msgid "Frame rate too high. Uploading might encounter issues."
 msgstr ""
 
-#: src/components/compose.jsx:2511
-#: src/components/compose.jsx:2761
+#: src/components/compose.jsx:2522
+#: src/components/compose.jsx:2772
 #: src/components/shortcuts-settings.jsx:726
 #: src/pages/catchup.jsx:1074
 #: src/pages/filters.jsx:412
 msgid "Remove"
 msgstr ""
 
-#: src/components/compose.jsx:2528
+#: src/components/compose.jsx:2539
 #: src/compose.jsx:83
 msgid "Error"
 msgstr ""
 
-#: src/components/compose.jsx:2553
+#: src/components/compose.jsx:2564
 msgid "Edit image description"
 msgstr ""
 
-#: src/components/compose.jsx:2554
+#: src/components/compose.jsx:2565
 msgid "Edit video description"
 msgstr ""
 
-#: src/components/compose.jsx:2555
+#: src/components/compose.jsx:2566
 msgid "Edit audio description"
 msgstr ""
 
-#: src/components/compose.jsx:2600
-#: src/components/compose.jsx:2649
+#: src/components/compose.jsx:2611
+#: src/components/compose.jsx:2660
 msgid "Generating description. Please wait…"
 msgstr ""
 
-#: src/components/compose.jsx:2620
+#: src/components/compose.jsx:2631
 msgid "Failed to generate description: {0}"
 msgstr ""
 
-#: src/components/compose.jsx:2621
+#: src/components/compose.jsx:2632
 msgid "Failed to generate description"
 msgstr ""
 
-#: src/components/compose.jsx:2633
-#: src/components/compose.jsx:2639
-#: src/components/compose.jsx:2685
+#: src/components/compose.jsx:2644
+#: src/components/compose.jsx:2650
+#: src/components/compose.jsx:2696
 msgid "Generate description…"
 msgstr ""
 
-#: src/components/compose.jsx:2672
+#: src/components/compose.jsx:2683
 msgid "Failed to generate description{0}"
 msgstr ""
 
-#: src/components/compose.jsx:2687
+#: src/components/compose.jsx:2698
 msgid "({0}) <0>— experimental</0>"
 msgstr ""
 
-#: src/components/compose.jsx:2706
+#: src/components/compose.jsx:2717
 msgid "Done"
 msgstr ""
 
-#: src/components/compose.jsx:2742
+#: src/components/compose.jsx:2753
 msgid "Choice {0}"
 msgstr ""
 
-#: src/components/compose.jsx:2789
+#: src/components/compose.jsx:2800
 msgid "Multiple choices"
 msgstr ""
 
-#: src/components/compose.jsx:2792
+#: src/components/compose.jsx:2803
 msgid "Duration"
 msgstr ""
 
-#: src/components/compose.jsx:2823
+#: src/components/compose.jsx:2834
 msgid "Remove poll"
 msgstr ""
 
-#: src/components/compose.jsx:3037
+#: src/components/compose.jsx:3048
 msgid "Search accounts"
 msgstr ""
 
-#: src/components/compose.jsx:3091
+#: src/components/compose.jsx:3102
 #: src/components/generic-accounts.jsx:227
 msgid "Error loading accounts"
 msgstr ""
 
-#: src/components/compose.jsx:3234
+#: src/components/compose.jsx:3245
 msgid "Custom emojis"
 msgstr ""
 
-#: src/components/compose.jsx:3254
+#: src/components/compose.jsx:3265
 msgid "Search emoji"
 msgstr ""
 
-#: src/components/compose.jsx:3285
+#: src/components/compose.jsx:3296
 msgid "Error loading custom emojis"
 msgstr ""
 
-#: src/components/compose.jsx:3296
+#: src/components/compose.jsx:3307
 msgid "Recently used"
 msgstr ""
 
-#: src/components/compose.jsx:3297
+#: src/components/compose.jsx:3308
 msgid "Others"
 msgstr ""
 
-#: src/components/compose.jsx:3335
+#: src/components/compose.jsx:3346
 msgid "{0} more…"
 msgstr ""
 
-#: src/components/compose.jsx:3473
+#: src/components/compose.jsx:3486
 msgid "Search GIFs"
 msgstr ""
 
-#: src/components/compose.jsx:3488
+#: src/components/compose.jsx:3501
 msgid "Powered by GIPHY"
 msgstr ""
 
-#: src/components/compose.jsx:3496
+#: src/components/compose.jsx:3509
 msgid "Type to search GIFs"
 msgstr ""
 
-#: src/components/compose.jsx:3594
+#: src/components/compose.jsx:3607
 #: src/components/media-modal.jsx:461
 #: src/components/timeline.jsx:889
 msgid "Previous"
 msgstr ""
 
-#: src/components/compose.jsx:3612
+#: src/components/compose.jsx:3625
 #: src/components/media-modal.jsx:480
 #: src/components/timeline.jsx:906
 msgid "Next"
 msgstr ""
 
-#: src/components/compose.jsx:3629
+#: src/components/compose.jsx:3642
 msgid "Error loading GIFs"
 msgstr ""
 


### PR DESCRIPTION
This is not meant to be a complete fix for #131 and #400, I didn’t want this PR to get too complex. This is only a first step in the right direction.

This makes sure that data from the `emojibase-data` package is preprocessed and placed into the `assets/emojis` directory. There is one file for each locale, with some files being identical to English because `emojibase-data`  doesn’t have translations for Czech for example.

The `getCustomEmojis` function has been modified to load both custom emojis and the locale-specific Unicode ones. The callers can then handle Unicode emojis with minimal changes.

Issues explicitly not addressed here:

* Both code and UI presentation still speak about “custom” emojis. This can be addressed in a subsequent cleanup.
* Quality of `emojibase-data` translation varies. For example, the gender neutral “scientist” is translated as “Wissenschaftler(in)” to German, the female “woman scientist” as “Wissenschaftlerin”. Both get the shortcode “wissenschaftlerin” – and Phanpy is using that shortcode as key, so React will complain about duplicate keys. Probably best to address this upstream, though some solution for duplicate shortcodes might also be in order.
* Also given the varying quality of translations, searching both translated and English emoji descriptions/shortcodes might be a good idea.
* I see tracking of recent emojis in the code but I don’t see it working in the UI. This code probably needs adapting as well.
* Emoji variants with different skin tones are present in the data but cannot currently be selected in the UI.
* Emoji subgroups are present in the data, not sure whether these need to be supported.
* Depending on OS support, some emojis currently won’t display. It’s possible to detect unsupported emojis, a better idea might be using a custom emoji font however.