### PR TITLE
[wip] Fix login with alternative domain

### DIFF
--- a/src/pages/login.css
+++ b/src/pages/login.css
@@ -60,3 +60,9 @@
   color: var(--text-insignificant-color);
   font-style: italic;
 }
+
+#settings input {
+  width: revert;
+  display: inline;
+  margin-top: 0.25em;
+}

--- a/src/pages/welcome.jsx
+++ b/src/pages/welcome.jsx
@@ -57,7 +57,7 @@ function Welcome() {
             <Link
               to={
                 DEFAULT_INSTANCE
-                  ? `/login?instance=${DEFAULT_INSTANCE}&submit=1`
+                  ? `/login?instance=${DEFAULT_INSTANCE}&submit=1&is_web_domain=true`
                   : '/login'
               }
               class="button"


### PR DESCRIPTION
Mastodon allows alternative web domains to be used for users  to interact with an instance. But host-meta shows only the    
web domain. This patch adds an option to allow user to specify whether they want to login with the domain entered or follow host-meta.

It seems that not many other clients are following this practice, so I'm not sure about these few things:
- Is this the expected behavior or the one to follow redirect is the expected behavior? Allowing to interact with alternative domain can help instances being blocked by firewalls to access them using the alternative domain.
- Do we need to add some supplementary info regarding this option? And how should we phrase it?