### PR TITLE
Improved post filtering support on Pleroma and Akkoma

### DIFF
--- a/src/components/status.jsx
+++ b/src/components/status.jsx
@@ -432,8 +432,6 @@ function Status({
   const regexFilters = useMemo(() => regexFilterLines.map(f => new RegExp(f)), [regexFilterLines])
   const regexFilterInfo = useMemo(() => regexFilters.map(f => content.search(f)), [regexFilters])
   const regexFilterTriggered = useMemo(() => regexFilterInfo.findIndex(f => f !== -1), [regexFilterInfo])
-  
-  console.debug("ASDF", "\ntext", regexFilterText, "\nlines", regexFilterLines, "\nregex", regexFilters, "\ninfo", regexFilterInfo, "\ntrigger", regexFilterTriggered)
 
   if (filterInfo?.action === 'hide') {
     return null;
@@ -3587,6 +3585,8 @@ function StatusCompact({ sKey }) {
   const filterInfo = isFiltered(filtered, filterContext);
 
   if (filterInfo?.action === 'hide') return null;
+  
+  console.debug('RENDER Status', id, status?.account.displayName, quoted);
 
   const filterTitleStr = filterInfo?.titlesStr || '';
 

--- a/src/components/status.jsx
+++ b/src/components/status.jsx
@@ -466,7 +466,7 @@ function Status({
         <FilteredStatus
           status={status}
           filterInfo={{
-            titlesStr: "Thread muted"
+            titlesStr: t`Thread muted`
           }}
           instance={instance}
           containerProps={{
@@ -494,9 +494,6 @@ function Status({
         />
       );
     }
-  }
-  
-  if (/*allowFilters && */ size !== 'l' && filterInfo) {
   }
 
   const createdAtDate = new Date(createdAt);

--- a/src/components/status.jsx
+++ b/src/components/status.jsx
@@ -345,6 +345,8 @@ function Status({
   if (!status) {
     return null;
   }
+  
+  console.debug("ASDF", status)
 
   const {
     account: {
@@ -393,6 +395,9 @@ function Status({
     // _filtered,
     // Non-Mastodon
     emojiReactions,
+    pleroma: {
+      threadMuted,
+    } = {}
   } = status;
 
   const [languageAutoDetected, setLanguageAutoDetected] = useState(null);
@@ -428,8 +433,6 @@ function Status({
     return null;
   }
 
-  console.debug('RENDER Status', id, status?.account.displayName, quoted);
-
   const debugHover = (e) => {
     if (e.shiftKey) {
       console.log({
@@ -438,7 +441,7 @@ function Status({
     }
   };
 
-  if (/*allowFilters && */ size !== 'l' && filterInfo) {
+  if (/*allowFilters && */ size !== 'l' && (filterInfo || threadMuted)) {
     return (
       <FilteredStatus
         status={status}

--- a/src/locales/en.po
+++ b/src/locales/en.po
@@ -34,7 +34,7 @@ msgstr ""
 
 #: src/components/account-block.jsx:169
 #: src/components/account-info.jsx:641
-#: src/components/status.jsx:514
+#: src/components/status.jsx:562
 msgid "Group"
 msgstr ""
 
@@ -111,11 +111,11 @@ msgstr ""
 #: src/components/compose.jsx:2624
 #: src/components/media-alt-modal.jsx:46
 #: src/components/media-modal.jsx:358
-#: src/components/status.jsx:1737
-#: src/components/status.jsx:1754
-#: src/components/status.jsx:1878
-#: src/components/status.jsx:2490
-#: src/components/status.jsx:2493
+#: src/components/status.jsx:1785
+#: src/components/status.jsx:1802
+#: src/components/status.jsx:1926
+#: src/components/status.jsx:2538
+#: src/components/status.jsx:2541
 #: src/pages/account-statuses.jsx:527
 #: src/pages/accounts.jsx:110
 #: src/pages/hashtag.jsx:200
@@ -196,7 +196,7 @@ msgid "Original"
 msgstr ""
 
 #: src/components/account-info.jsx:864
-#: src/components/status.jsx:2268
+#: src/components/status.jsx:2316
 #: src/pages/catchup.jsx:71
 #: src/pages/catchup.jsx:1445
 #: src/pages/catchup.jsx:2058
@@ -209,7 +209,7 @@ msgstr ""
 #: src/pages/catchup.jsx:72
 #: src/pages/catchup.jsx:1447
 #: src/pages/catchup.jsx:2070
-#: src/pages/settings.jsx:1155
+#: src/pages/settings.jsx:1180
 msgid "Boosts"
 msgstr ""
 
@@ -293,30 +293,30 @@ msgid "Add/Remove from Lists"
 msgstr ""
 
 #: src/components/account-info.jsx:1304
-#: src/components/status.jsx:1177
+#: src/components/status.jsx:1225
 msgid "Link copied"
 msgstr ""
 
 #: src/components/account-info.jsx:1307
-#: src/components/status.jsx:1180
+#: src/components/status.jsx:1228
 msgid "Unable to copy link"
 msgstr ""
 
 #: src/components/account-info.jsx:1313
 #: src/components/shortcuts-settings.jsx:1059
-#: src/components/status.jsx:1186
-#: src/components/status.jsx:3269
+#: src/components/status.jsx:1234
+#: src/components/status.jsx:3317
 msgid "Copy"
 msgstr ""
 
 #: src/components/account-info.jsx:1328
 #: src/components/shortcuts-settings.jsx:1077
-#: src/components/status.jsx:1202
+#: src/components/status.jsx:1250
 msgid "Sharing doesn't seem to work."
 msgstr ""
 
 #: src/components/account-info.jsx:1334
-#: src/components/status.jsx:1208
+#: src/components/status.jsx:1256
 msgid "Share…"
 msgstr ""
 
@@ -435,9 +435,9 @@ msgstr ""
 #: src/components/shortcuts-settings.jsx:230
 #: src/components/shortcuts-settings.jsx:583
 #: src/components/shortcuts-settings.jsx:783
-#: src/components/status.jsx:2993
-#: src/components/status.jsx:3233
-#: src/components/status.jsx:3733
+#: src/components/status.jsx:3041
+#: src/components/status.jsx:3281
+#: src/components/status.jsx:3781
 #: src/pages/accounts.jsx:37
 #: src/pages/catchup.jsx:1581
 #: src/pages/filters.jsx:224
@@ -649,7 +649,7 @@ msgid "Attachment #{i} failed"
 msgstr "Attachment #{i} failed"
 
 #: src/components/compose.jsx:1180
-#: src/components/status.jsx:2063
+#: src/components/status.jsx:2111
 #: src/components/timeline.jsx:989
 msgid "Content warning"
 msgstr ""
@@ -685,7 +685,7 @@ msgstr ""
 
 #: src/components/compose.jsx:1247
 #: src/components/status.jsx:97
-#: src/components/status.jsx:1941
+#: src/components/status.jsx:1989
 msgid "Private mention"
 msgstr ""
 
@@ -714,10 +714,10 @@ msgstr ""
 
 #: src/components/compose.jsx:1555
 #: src/components/keyboard-shortcuts-help.jsx:152
-#: src/components/status.jsx:929
-#: src/components/status.jsx:1717
-#: src/components/status.jsx:1718
-#: src/components/status.jsx:2386
+#: src/components/status.jsx:977
+#: src/components/status.jsx:1765
+#: src/components/status.jsx:1766
+#: src/components/status.jsx:2434
 msgid "Reply"
 msgstr ""
 
@@ -931,7 +931,7 @@ msgid "Error loading GIFs"
 msgstr ""
 
 #: src/components/drafts.jsx:64
-#: src/pages/settings.jsx:693
+#: src/pages/settings.jsx:718
 msgid "Unsent drafts"
 msgstr ""
 
@@ -949,7 +949,7 @@ msgstr ""
 
 #: src/components/drafts.jsx:128
 #: src/components/list-add-edit.jsx:186
-#: src/components/status.jsx:1352
+#: src/components/status.jsx:1400
 #: src/pages/filters.jsx:587
 msgid "Delete…"
 msgstr ""
@@ -1157,10 +1157,10 @@ msgid "<0>l</0> or <1>f</1>"
 msgstr ""
 
 #: src/components/keyboard-shortcuts-help.jsx:173
-#: src/components/status.jsx:937
-#: src/components/status.jsx:2413
-#: src/components/status.jsx:2444
-#: src/components/status.jsx:2445
+#: src/components/status.jsx:985
+#: src/components/status.jsx:2461
+#: src/components/status.jsx:2492
+#: src/components/status.jsx:2493
 msgid "Boost"
 msgstr ""
 
@@ -1169,9 +1169,9 @@ msgid "<0>Shift</0> + <1>b</1>"
 msgstr ""
 
 #: src/components/keyboard-shortcuts-help.jsx:181
-#: src/components/status.jsx:1022
-#: src/components/status.jsx:2469
-#: src/components/status.jsx:2470
+#: src/components/status.jsx:1070
+#: src/components/status.jsx:2517
+#: src/components/status.jsx:2518
 msgid "Bookmark"
 msgstr ""
 
@@ -1230,15 +1230,15 @@ msgid "Media description"
 msgstr ""
 
 #: src/components/media-alt-modal.jsx:58
-#: src/components/status.jsx:1066
-#: src/components/status.jsx:1093
+#: src/components/status.jsx:1114
+#: src/components/status.jsx:1141
 #: src/components/translation-block.jsx:196
 msgid "Translate"
 msgstr ""
 
 #: src/components/media-alt-modal.jsx:69
-#: src/components/status.jsx:1080
-#: src/components/status.jsx:1107
+#: src/components/status.jsx:1128
+#: src/components/status.jsx:1155
 msgid "Speak"
 msgstr ""
 
@@ -1275,9 +1275,9 @@ msgid "Filtered: {filterTitleStr}"
 msgstr ""
 
 #: src/components/media-post.jsx:134
-#: src/components/status.jsx:3563
-#: src/components/status.jsx:3659
-#: src/components/status.jsx:3737
+#: src/components/status.jsx:3611
+#: src/components/status.jsx:3707
+#: src/components/status.jsx:3785
 #: src/components/timeline.jsx:978
 #: src/pages/catchup.jsx:75
 #: src/pages/catchup.jsx:1877
@@ -1327,7 +1327,7 @@ msgstr ""
 #: src/pages/home.jsx:225
 #: src/pages/mentions.jsx:21
 #: src/pages/mentions.jsx:168
-#: src/pages/settings.jsx:1147
+#: src/pages/settings.jsx:1172
 #: src/pages/trending.jsx:382
 msgid "Mentions"
 msgstr ""
@@ -1366,7 +1366,7 @@ msgstr ""
 #: src/pages/catchup.jsx:2064
 #: src/pages/favourites.jsx:12
 #: src/pages/favourites.jsx:24
-#: src/pages/settings.jsx:1151
+#: src/pages/settings.jsx:1176
 msgid "Likes"
 msgstr ""
 
@@ -1576,8 +1576,8 @@ msgid "[Unknown notification type: {type}]"
 msgstr ""
 
 #: src/components/notification.jsx:441
-#: src/components/status.jsx:1036
-#: src/components/status.jsx:1046
+#: src/components/status.jsx:1084
+#: src/components/status.jsx:1094
 msgid "Boosted/Liked by…"
 msgstr ""
 
@@ -1904,7 +1904,7 @@ msgid "Move down"
 msgstr ""
 
 #: src/components/shortcuts-settings.jsx:379
-#: src/components/status.jsx:1314
+#: src/components/status.jsx:1362
 #: src/pages/list.jsx:171
 msgid "Edit"
 msgstr ""
@@ -2103,320 +2103,320 @@ msgstr ""
 msgid "Import/export settings from/to instance server (Very experimental)"
 msgstr ""
 
-#: src/components/status.jsx:538
+#: src/components/status.jsx:586
 msgid "<0/> <1>boosted</1>"
 msgstr ""
 
-#: src/components/status.jsx:637
+#: src/components/status.jsx:685
 msgid "Sorry, your current logged-in instance can't interact with this post from another instance."
 msgstr ""
 
 #. placeholder {0}: username || acct
-#: src/components/status.jsx:790
+#: src/components/status.jsx:838
 msgid "Unliked @{0}'s post"
 msgstr ""
 
 #. placeholder {1}: username || acct
-#: src/components/status.jsx:791
+#: src/components/status.jsx:839
 msgid "Liked @{1}'s post"
 msgstr "Liked @{1}'s post"
 
 #. placeholder {2}: username || acct
-#: src/components/status.jsx:830
+#: src/components/status.jsx:878
 msgid "Unbookmarked @{2}'s post"
 msgstr "Unbookmarked @{2}'s post"
 
 #. placeholder {3}: username || acct
-#: src/components/status.jsx:831
+#: src/components/status.jsx:879
 msgid "Bookmarked @{3}'s post"
 msgstr "Bookmarked @{3}'s post"
 
-#: src/components/status.jsx:937
-#: src/components/status.jsx:999
-#: src/components/status.jsx:2413
-#: src/components/status.jsx:2444
+#: src/components/status.jsx:985
+#: src/components/status.jsx:1047
+#: src/components/status.jsx:2461
+#: src/components/status.jsx:2492
 msgid "Unboost"
 msgstr ""
 
-#: src/components/status.jsx:953
-#: src/components/status.jsx:2428
+#: src/components/status.jsx:1001
+#: src/components/status.jsx:2476
 msgid "Quote"
 msgstr ""
 
-#: src/components/status.jsx:961
-#: src/components/status.jsx:2437
+#: src/components/status.jsx:1009
+#: src/components/status.jsx:2485
 msgid "Some media have no descriptions."
 msgstr ""
 
 #. placeholder {0}: rtf.format(-statusMonthsAgo, 'month')
-#: src/components/status.jsx:968
+#: src/components/status.jsx:1016
 msgid "Old post (<0>{0}</0>)"
 msgstr ""
 
 #. placeholder {4}: username || acct
-#: src/components/status.jsx:987
+#: src/components/status.jsx:1035
 msgid "Unboosted @{4}'s post"
 msgstr "Unboosted @{4}'s post"
 
 #. placeholder {5}: username || acct
-#: src/components/status.jsx:988
+#: src/components/status.jsx:1036
 msgid "Boosted @{5}'s post"
 msgstr "Boosted @{5}'s post"
 
-#: src/components/status.jsx:1000
+#: src/components/status.jsx:1048
 msgid "Boost…"
 msgstr ""
 
-#: src/components/status.jsx:1012
-#: src/components/status.jsx:1727
-#: src/components/status.jsx:2457
+#: src/components/status.jsx:1060
+#: src/components/status.jsx:1775
+#: src/components/status.jsx:2505
 msgid "Unlike"
 msgstr ""
 
-#: src/components/status.jsx:1013
-#: src/components/status.jsx:1727
-#: src/components/status.jsx:1728
-#: src/components/status.jsx:2457
-#: src/components/status.jsx:2458
+#: src/components/status.jsx:1061
+#: src/components/status.jsx:1775
+#: src/components/status.jsx:1776
+#: src/components/status.jsx:2505
+#: src/components/status.jsx:2506
 msgid "Like"
 msgstr ""
 
-#: src/components/status.jsx:1022
-#: src/components/status.jsx:2469
+#: src/components/status.jsx:1070
+#: src/components/status.jsx:2517
 msgid "Unbookmark"
 msgstr ""
 
 #. placeholder {0}: username || acct
-#: src/components/status.jsx:1130
+#: src/components/status.jsx:1178
 msgid "View post by <0>@{0}</0>"
 msgstr ""
 
-#: src/components/status.jsx:1151
+#: src/components/status.jsx:1199
 msgid "Show Edit History"
 msgstr ""
 
-#: src/components/status.jsx:1154
+#: src/components/status.jsx:1202
 msgid "Edited: {editedDateText}"
 msgstr ""
 
-#: src/components/status.jsx:1221
-#: src/components/status.jsx:3238
+#: src/components/status.jsx:1269
+#: src/components/status.jsx:3286
 msgid "Embed post"
 msgstr ""
 
-#: src/components/status.jsx:1235
+#: src/components/status.jsx:1283
 msgid "Conversation unmuted"
 msgstr ""
 
-#: src/components/status.jsx:1235
+#: src/components/status.jsx:1283
 msgid "Conversation muted"
 msgstr ""
 
-#: src/components/status.jsx:1241
+#: src/components/status.jsx:1289
 msgid "Unable to unmute conversation"
 msgstr ""
 
-#: src/components/status.jsx:1242
+#: src/components/status.jsx:1290
 msgid "Unable to mute conversation"
 msgstr ""
 
-#: src/components/status.jsx:1251
+#: src/components/status.jsx:1299
 msgid "Unmute conversation"
 msgstr ""
 
-#: src/components/status.jsx:1258
+#: src/components/status.jsx:1306
 msgid "Mute conversation"
 msgstr ""
 
-#: src/components/status.jsx:1274
+#: src/components/status.jsx:1322
 msgid "Post unpinned from profile"
 msgstr ""
 
-#: src/components/status.jsx:1275
+#: src/components/status.jsx:1323
 msgid "Post pinned to profile"
 msgstr ""
 
-#: src/components/status.jsx:1280
+#: src/components/status.jsx:1328
 msgid "Unable to unpin post"
 msgstr ""
 
-#: src/components/status.jsx:1280
+#: src/components/status.jsx:1328
 msgid "Unable to pin post"
 msgstr ""
 
-#: src/components/status.jsx:1289
+#: src/components/status.jsx:1337
 msgid "Unpin from profile"
 msgstr ""
 
-#: src/components/status.jsx:1296
+#: src/components/status.jsx:1344
 msgid "Pin to profile"
 msgstr ""
 
-#: src/components/status.jsx:1325
+#: src/components/status.jsx:1373
 msgid "Delete this post?"
 msgstr ""
 
-#: src/components/status.jsx:1341
+#: src/components/status.jsx:1389
 msgid "Post deleted"
 msgstr ""
 
-#: src/components/status.jsx:1344
+#: src/components/status.jsx:1392
 msgid "Unable to delete post"
 msgstr ""
 
-#: src/components/status.jsx:1372
+#: src/components/status.jsx:1420
 msgid "Report post…"
 msgstr ""
 
 #. placeholder {6}: username || acct
-#: src/components/status.jsx:1442
+#: src/components/status.jsx:1490
 msgid "Unboosted @{6}'s post"
 msgstr "Unboosted @{6}'s post"
 
 #. placeholder {7}: username || acct
-#: src/components/status.jsx:1443
+#: src/components/status.jsx:1491
 msgid "Boosted @{7}'s post"
 msgstr "Boosted @{7}'s post"
 
-#: src/components/status.jsx:1728
-#: src/components/status.jsx:1764
-#: src/components/status.jsx:2458
+#: src/components/status.jsx:1776
+#: src/components/status.jsx:1812
+#: src/components/status.jsx:2506
 msgid "Liked"
 msgstr ""
 
-#: src/components/status.jsx:1761
-#: src/components/status.jsx:2445
+#: src/components/status.jsx:1809
+#: src/components/status.jsx:2493
 msgid "Boosted"
 msgstr ""
 
-#: src/components/status.jsx:1771
-#: src/components/status.jsx:2470
+#: src/components/status.jsx:1819
+#: src/components/status.jsx:2518
 msgid "Bookmarked"
 msgstr ""
 
-#: src/components/status.jsx:1775
+#: src/components/status.jsx:1823
 msgid "Pinned"
 msgstr ""
 
-#: src/components/status.jsx:1820
-#: src/components/status.jsx:2276
+#: src/components/status.jsx:1868
+#: src/components/status.jsx:2324
 msgid "Deleted"
 msgstr ""
 
-#: src/components/status.jsx:1861
+#: src/components/status.jsx:1909
 msgid "{repliesCount, plural, one {# reply} other {# replies}}"
 msgstr ""
 
 #. placeholder {0}: snapStates.statusThreadNumber[sKey] ? ` ${snapStates.statusThreadNumber[sKey]}/X` : ''
-#: src/components/status.jsx:1950
+#: src/components/status.jsx:1998
 msgid "Thread{0}"
 msgstr ""
 
-#: src/components/status.jsx:2026
-#: src/components/status.jsx:2088
-#: src/components/status.jsx:2173
+#: src/components/status.jsx:2074
+#: src/components/status.jsx:2136
+#: src/components/status.jsx:2221
 msgid "Show less"
 msgstr ""
 
-#: src/components/status.jsx:2026
-#: src/components/status.jsx:2088
+#: src/components/status.jsx:2074
+#: src/components/status.jsx:2136
 msgid "Show content"
 msgstr ""
 
-#: src/components/status.jsx:2173
+#: src/components/status.jsx:2221
 msgid "Show media"
 msgstr ""
 
-#: src/components/status.jsx:2310
+#: src/components/status.jsx:2358
 msgid "Edited"
 msgstr ""
 
-#: src/components/status.jsx:2387
+#: src/components/status.jsx:2435
 msgid "Comments"
 msgstr ""
 
 #. More from [Author]
-#: src/components/status.jsx:2696
+#: src/components/status.jsx:2744
 msgid "More from <0/>"
 msgstr "More from <0/>"
 
-#: src/components/status.jsx:2998
+#: src/components/status.jsx:3046
 msgid "Edit History"
 msgstr ""
 
-#: src/components/status.jsx:3002
+#: src/components/status.jsx:3050
 msgid "Failed to load history"
 msgstr ""
 
-#: src/components/status.jsx:3007
+#: src/components/status.jsx:3055
 #: src/pages/annual-report.jsx:45
 msgid "Loading…"
 msgstr ""
 
-#: src/components/status.jsx:3243
+#: src/components/status.jsx:3291
 msgid "HTML Code"
 msgstr ""
 
-#: src/components/status.jsx:3260
+#: src/components/status.jsx:3308
 msgid "HTML code copied"
 msgstr ""
 
-#: src/components/status.jsx:3263
+#: src/components/status.jsx:3311
 msgid "Unable to copy HTML code"
 msgstr ""
 
-#: src/components/status.jsx:3275
+#: src/components/status.jsx:3323
 msgid "Media attachments:"
 msgstr ""
 
-#: src/components/status.jsx:3297
+#: src/components/status.jsx:3345
 msgid "Account Emojis:"
 msgstr ""
 
-#: src/components/status.jsx:3328
-#: src/components/status.jsx:3373
+#: src/components/status.jsx:3376
+#: src/components/status.jsx:3421
 msgid "static URL"
 msgstr ""
 
-#: src/components/status.jsx:3342
+#: src/components/status.jsx:3390
 msgid "Emojis:"
 msgstr ""
 
-#: src/components/status.jsx:3387
+#: src/components/status.jsx:3435
 msgid "Notes:"
 msgstr ""
 
-#: src/components/status.jsx:3391
+#: src/components/status.jsx:3439
 msgid "This is static, unstyled and scriptless. You may need to apply your own styles and edit as needed."
 msgstr ""
 
-#: src/components/status.jsx:3397
+#: src/components/status.jsx:3445
 msgid "Polls are not interactive, becomes a list with vote counts."
 msgstr ""
 
-#: src/components/status.jsx:3402
+#: src/components/status.jsx:3450
 msgid "Media attachments can be images, videos, audios or any file types."
 msgstr ""
 
-#: src/components/status.jsx:3408
+#: src/components/status.jsx:3456
 msgid "Post could be edited or deleted later."
 msgstr ""
 
-#: src/components/status.jsx:3414
+#: src/components/status.jsx:3462
 msgid "Preview"
 msgstr ""
 
-#: src/components/status.jsx:3423
+#: src/components/status.jsx:3471
 msgid "Note: This preview is lightly styled."
 msgstr ""
 
 #. [Name] [Visibility icon] boosted
-#: src/components/status.jsx:3667
+#: src/components/status.jsx:3715
 msgid "<0/> <1/> boosted"
 msgstr ""
 
 #: src/components/timeline.jsx:455
-#: src/pages/settings.jsx:1175
+#: src/pages/settings.jsx:1200
 msgid "New posts"
 msgstr ""
 
@@ -3290,7 +3290,7 @@ msgid "{0, plural, one {Announcement} other {Announcements}}"
 msgstr ""
 
 #: src/pages/notifications.jsx:654
-#: src/pages/settings.jsx:1163
+#: src/pages/settings.jsx:1188
 msgid "Follow requests"
 msgstr ""
 
@@ -3617,95 +3617,103 @@ msgstr ""
 msgid "Replace text as blocks, useful when taking screenshots, for privacy reasons."
 msgstr ""
 
-#: src/pages/settings.jsx:701
+#: src/pages/settings.jsx:686
+msgid "Regex mutes"
+msgstr "Regex mutes"
+
+#: src/pages/settings.jsx:702
+msgid "Mute posts matching these regular expressions. One per line. Make sure that the final regular expression is terminated by a newline character, or it won't be parsed!"
+msgstr "Mute posts matching these regular expressions. One per line. Make sure that the final regular expression is terminated by a newline character, or it won't be parsed!"
+
+#: src/pages/settings.jsx:726
 msgid "About"
 msgstr ""
 
-#: src/pages/settings.jsx:740
+#: src/pages/settings.jsx:765
 msgid "<0>Built</0> by <1>@cheeaun</1>"
 msgstr ""
 
-#: src/pages/settings.jsx:769
+#: src/pages/settings.jsx:794
 msgid "Sponsor"
 msgstr ""
 
-#: src/pages/settings.jsx:777
+#: src/pages/settings.jsx:802
 msgid "Donate"
 msgstr "Donate"
 
-#: src/pages/settings.jsx:793
+#: src/pages/settings.jsx:818
 msgid "Privacy Policy"
 msgstr ""
 
 #. placeholder {0}: WEBSITE.replace(/https?:\/\//g, '').replace(/\/$/, '')
-#: src/pages/settings.jsx:800
+#: src/pages/settings.jsx:825
 msgid "<0>Site:</0> {0}"
 msgstr ""
 
 #. placeholder {0}: !__FAKE_COMMIT_HASH__ && ( <span class="ib insignificant"> ( <a href={`https://github.com/cheeaun/phanpy/commit/${__COMMIT_HASH__}`} target="_blank" rel="noopener noreferrer" > <RelativeTime datetime={new Date(__BUILD_TIME__)} /> </a> ) </span> )
-#: src/pages/settings.jsx:807
+#: src/pages/settings.jsx:832
 msgid "<0>Version:</0> <1/> {0}"
 msgstr ""
 
-#: src/pages/settings.jsx:822
+#: src/pages/settings.jsx:847
 msgid "Version string copied"
 msgstr ""
 
-#: src/pages/settings.jsx:825
+#: src/pages/settings.jsx:850
 msgid "Unable to copy version string"
 msgstr ""
 
-#: src/pages/settings.jsx:1060
-#: src/pages/settings.jsx:1065
+#: src/pages/settings.jsx:1085
+#: src/pages/settings.jsx:1090
 msgid "Failed to update subscription. Please try again."
 msgstr ""
 
-#: src/pages/settings.jsx:1071
+#: src/pages/settings.jsx:1096
 msgid "Failed to remove subscription. Please try again."
 msgstr ""
 
-#: src/pages/settings.jsx:1078
+#: src/pages/settings.jsx:1103
 msgid "Push Notifications (beta)"
 msgstr ""
 
-#: src/pages/settings.jsx:1100
+#: src/pages/settings.jsx:1125
 msgid "Push notifications are blocked. Please enable them in your browser settings."
 msgstr ""
 
 #. placeholder {0}: [ { value: 'all', label: t`anyone`, }, { value: 'followed', label: t`people I follow`, }, { value: 'follower', label: t`followers`, }, ].map((type) => ( <option value={type.value}>{type.label}</option> ))
-#: src/pages/settings.jsx:1109
+#: src/pages/settings.jsx:1134
 msgid "Allow from <0>{0}</0>"
 msgstr ""
 
-#: src/pages/settings.jsx:1118
+#: src/pages/settings.jsx:1143
 msgid "anyone"
 msgstr ""
 
-#: src/pages/settings.jsx:1122
+#: src/pages/settings.jsx:1147
 msgid "people I follow"
 msgstr ""
 
-#: src/pages/settings.jsx:1126
+#: src/pages/settings.jsx:1151
 msgid "followers"
 msgstr ""
 
-#: src/pages/settings.jsx:1159
+#: src/pages/settings.jsx:1184
 msgid "Follows"
 msgstr ""
 
-#: src/pages/settings.jsx:1167
+#: src/pages/settings.jsx:1192
 msgid "Polls"
 msgstr ""
 
-#: src/pages/settings.jsx:1171
+#: src/pages/settings.jsx:1196
 msgid "Post edits"
 msgstr ""
 
-#: src/pages/settings.jsx:1192
+#: src/pages/settings.jsx:1217
 msgid "Push permission was not granted since your last login. You'll need to <0><1>log in</1> again to grant push permission</0>."
 msgstr ""
 
-#: src/pages/settings.jsx:1208
+#: src/pages/settings.jsx:1233
 msgid "NOTE: Push notifications only work for <0>one account</0>."
 msgstr ""
 

--- a/src/locales/en.po
+++ b/src/locales/en.po
@@ -34,7 +34,7 @@ msgstr ""
 
 #: src/components/account-block.jsx:169
 #: src/components/account-info.jsx:641
-#: src/components/status.jsx:562
+#: src/components/status.jsx:560
 msgid "Group"
 msgstr ""
 
@@ -111,11 +111,11 @@ msgstr ""
 #: src/components/compose.jsx:2624
 #: src/components/media-alt-modal.jsx:46
 #: src/components/media-modal.jsx:358
-#: src/components/status.jsx:1785
-#: src/components/status.jsx:1802
-#: src/components/status.jsx:1926
-#: src/components/status.jsx:2538
-#: src/components/status.jsx:2541
+#: src/components/status.jsx:1783
+#: src/components/status.jsx:1800
+#: src/components/status.jsx:1924
+#: src/components/status.jsx:2536
+#: src/components/status.jsx:2539
 #: src/pages/account-statuses.jsx:527
 #: src/pages/accounts.jsx:110
 #: src/pages/hashtag.jsx:200
@@ -196,7 +196,7 @@ msgid "Original"
 msgstr ""
 
 #: src/components/account-info.jsx:864
-#: src/components/status.jsx:2316
+#: src/components/status.jsx:2314
 #: src/pages/catchup.jsx:71
 #: src/pages/catchup.jsx:1445
 #: src/pages/catchup.jsx:2058
@@ -293,30 +293,30 @@ msgid "Add/Remove from Lists"
 msgstr ""
 
 #: src/components/account-info.jsx:1304
-#: src/components/status.jsx:1225
+#: src/components/status.jsx:1223
 msgid "Link copied"
 msgstr ""
 
 #: src/components/account-info.jsx:1307
-#: src/components/status.jsx:1228
+#: src/components/status.jsx:1226
 msgid "Unable to copy link"
 msgstr ""
 
 #: src/components/account-info.jsx:1313
 #: src/components/shortcuts-settings.jsx:1059
-#: src/components/status.jsx:1234
-#: src/components/status.jsx:3317
+#: src/components/status.jsx:1232
+#: src/components/status.jsx:3315
 msgid "Copy"
 msgstr ""
 
 #: src/components/account-info.jsx:1328
 #: src/components/shortcuts-settings.jsx:1077
-#: src/components/status.jsx:1250
+#: src/components/status.jsx:1248
 msgid "Sharing doesn't seem to work."
 msgstr ""
 
 #: src/components/account-info.jsx:1334
-#: src/components/status.jsx:1256
+#: src/components/status.jsx:1254
 msgid "Share…"
 msgstr ""
 
@@ -435,8 +435,8 @@ msgstr ""
 #: src/components/shortcuts-settings.jsx:230
 #: src/components/shortcuts-settings.jsx:583
 #: src/components/shortcuts-settings.jsx:783
-#: src/components/status.jsx:3041
-#: src/components/status.jsx:3281
+#: src/components/status.jsx:3039
+#: src/components/status.jsx:3279
 #: src/components/status.jsx:3781
 #: src/pages/accounts.jsx:37
 #: src/pages/catchup.jsx:1581
@@ -649,7 +649,7 @@ msgid "Attachment #{i} failed"
 msgstr "Attachment #{i} failed"
 
 #: src/components/compose.jsx:1180
-#: src/components/status.jsx:2111
+#: src/components/status.jsx:2109
 #: src/components/timeline.jsx:989
 msgid "Content warning"
 msgstr ""
@@ -685,7 +685,7 @@ msgstr ""
 
 #: src/components/compose.jsx:1247
 #: src/components/status.jsx:97
-#: src/components/status.jsx:1989
+#: src/components/status.jsx:1987
 msgid "Private mention"
 msgstr ""
 
@@ -714,10 +714,10 @@ msgstr ""
 
 #: src/components/compose.jsx:1555
 #: src/components/keyboard-shortcuts-help.jsx:152
-#: src/components/status.jsx:977
-#: src/components/status.jsx:1765
-#: src/components/status.jsx:1766
-#: src/components/status.jsx:2434
+#: src/components/status.jsx:975
+#: src/components/status.jsx:1763
+#: src/components/status.jsx:1764
+#: src/components/status.jsx:2432
 msgid "Reply"
 msgstr ""
 
@@ -949,7 +949,7 @@ msgstr ""
 
 #: src/components/drafts.jsx:128
 #: src/components/list-add-edit.jsx:186
-#: src/components/status.jsx:1400
+#: src/components/status.jsx:1398
 #: src/pages/filters.jsx:587
 msgid "Delete…"
 msgstr ""
@@ -1157,10 +1157,10 @@ msgid "<0>l</0> or <1>f</1>"
 msgstr ""
 
 #: src/components/keyboard-shortcuts-help.jsx:173
-#: src/components/status.jsx:985
-#: src/components/status.jsx:2461
-#: src/components/status.jsx:2492
-#: src/components/status.jsx:2493
+#: src/components/status.jsx:983
+#: src/components/status.jsx:2459
+#: src/components/status.jsx:2490
+#: src/components/status.jsx:2491
 msgid "Boost"
 msgstr ""
 
@@ -1169,9 +1169,9 @@ msgid "<0>Shift</0> + <1>b</1>"
 msgstr ""
 
 #: src/components/keyboard-shortcuts-help.jsx:181
-#: src/components/status.jsx:1070
-#: src/components/status.jsx:2517
-#: src/components/status.jsx:2518
+#: src/components/status.jsx:1068
+#: src/components/status.jsx:2515
+#: src/components/status.jsx:2516
 msgid "Bookmark"
 msgstr ""
 
@@ -1230,15 +1230,15 @@ msgid "Media description"
 msgstr ""
 
 #: src/components/media-alt-modal.jsx:58
-#: src/components/status.jsx:1114
-#: src/components/status.jsx:1141
+#: src/components/status.jsx:1112
+#: src/components/status.jsx:1139
 #: src/components/translation-block.jsx:196
 msgid "Translate"
 msgstr ""
 
 #: src/components/media-alt-modal.jsx:69
-#: src/components/status.jsx:1128
-#: src/components/status.jsx:1155
+#: src/components/status.jsx:1126
+#: src/components/status.jsx:1153
 msgid "Speak"
 msgstr ""
 
@@ -1576,8 +1576,8 @@ msgid "[Unknown notification type: {type}]"
 msgstr ""
 
 #: src/components/notification.jsx:441
-#: src/components/status.jsx:1084
-#: src/components/status.jsx:1094
+#: src/components/status.jsx:1082
+#: src/components/status.jsx:1092
 msgid "Boosted/Liked by…"
 msgstr ""
 
@@ -1904,7 +1904,7 @@ msgid "Move down"
 msgstr ""
 
 #: src/components/shortcuts-settings.jsx:379
-#: src/components/status.jsx:1362
+#: src/components/status.jsx:1360
 #: src/pages/list.jsx:171
 msgid "Edit"
 msgstr ""
@@ -2103,310 +2103,310 @@ msgstr ""
 msgid "Import/export settings from/to instance server (Very experimental)"
 msgstr ""
 
-#: src/components/status.jsx:586
+#: src/components/status.jsx:584
 msgid "<0/> <1>boosted</1>"
 msgstr ""
 
-#: src/components/status.jsx:685
+#: src/components/status.jsx:683
 msgid "Sorry, your current logged-in instance can't interact with this post from another instance."
 msgstr ""
 
 #. placeholder {0}: username || acct
-#: src/components/status.jsx:838
+#: src/components/status.jsx:836
 msgid "Unliked @{0}'s post"
 msgstr ""
 
 #. placeholder {1}: username || acct
-#: src/components/status.jsx:839
+#: src/components/status.jsx:837
 msgid "Liked @{1}'s post"
 msgstr "Liked @{1}'s post"
 
 #. placeholder {2}: username || acct
-#: src/components/status.jsx:878
+#: src/components/status.jsx:876
 msgid "Unbookmarked @{2}'s post"
 msgstr "Unbookmarked @{2}'s post"
 
 #. placeholder {3}: username || acct
-#: src/components/status.jsx:879
+#: src/components/status.jsx:877
 msgid "Bookmarked @{3}'s post"
 msgstr "Bookmarked @{3}'s post"
 
-#: src/components/status.jsx:985
-#: src/components/status.jsx:1047
-#: src/components/status.jsx:2461
-#: src/components/status.jsx:2492
+#: src/components/status.jsx:983
+#: src/components/status.jsx:1045
+#: src/components/status.jsx:2459
+#: src/components/status.jsx:2490
 msgid "Unboost"
 msgstr ""
 
-#: src/components/status.jsx:1001
-#: src/components/status.jsx:2476
+#: src/components/status.jsx:999
+#: src/components/status.jsx:2474
 msgid "Quote"
 msgstr ""
 
-#: src/components/status.jsx:1009
-#: src/components/status.jsx:2485
+#: src/components/status.jsx:1007
+#: src/components/status.jsx:2483
 msgid "Some media have no descriptions."
 msgstr ""
 
 #. placeholder {0}: rtf.format(-statusMonthsAgo, 'month')
-#: src/components/status.jsx:1016
+#: src/components/status.jsx:1014
 msgid "Old post (<0>{0}</0>)"
 msgstr ""
 
 #. placeholder {4}: username || acct
-#: src/components/status.jsx:1035
+#: src/components/status.jsx:1033
 msgid "Unboosted @{4}'s post"
 msgstr "Unboosted @{4}'s post"
 
 #. placeholder {5}: username || acct
-#: src/components/status.jsx:1036
+#: src/components/status.jsx:1034
 msgid "Boosted @{5}'s post"
 msgstr "Boosted @{5}'s post"
 
-#: src/components/status.jsx:1048
+#: src/components/status.jsx:1046
 msgid "Boost…"
 msgstr ""
 
-#: src/components/status.jsx:1060
-#: src/components/status.jsx:1775
-#: src/components/status.jsx:2505
+#: src/components/status.jsx:1058
+#: src/components/status.jsx:1773
+#: src/components/status.jsx:2503
 msgid "Unlike"
 msgstr ""
 
-#: src/components/status.jsx:1061
-#: src/components/status.jsx:1775
-#: src/components/status.jsx:1776
-#: src/components/status.jsx:2505
-#: src/components/status.jsx:2506
+#: src/components/status.jsx:1059
+#: src/components/status.jsx:1773
+#: src/components/status.jsx:1774
+#: src/components/status.jsx:2503
+#: src/components/status.jsx:2504
 msgid "Like"
 msgstr ""
 
-#: src/components/status.jsx:1070
-#: src/components/status.jsx:2517
+#: src/components/status.jsx:1068
+#: src/components/status.jsx:2515
 msgid "Unbookmark"
 msgstr ""
 
 #. placeholder {0}: username || acct
-#: src/components/status.jsx:1178
+#: src/components/status.jsx:1176
 msgid "View post by <0>@{0}</0>"
 msgstr ""
 
-#: src/components/status.jsx:1199
+#: src/components/status.jsx:1197
 msgid "Show Edit History"
 msgstr ""
 
-#: src/components/status.jsx:1202
+#: src/components/status.jsx:1200
 msgid "Edited: {editedDateText}"
 msgstr ""
 
-#: src/components/status.jsx:1269
-#: src/components/status.jsx:3286
+#: src/components/status.jsx:1267
+#: src/components/status.jsx:3284
 msgid "Embed post"
 msgstr ""
 
-#: src/components/status.jsx:1283
+#: src/components/status.jsx:1281
 msgid "Conversation unmuted"
 msgstr ""
 
-#: src/components/status.jsx:1283
+#: src/components/status.jsx:1281
 msgid "Conversation muted"
 msgstr ""
 
-#: src/components/status.jsx:1289
+#: src/components/status.jsx:1287
 msgid "Unable to unmute conversation"
 msgstr ""
 
-#: src/components/status.jsx:1290
+#: src/components/status.jsx:1288
 msgid "Unable to mute conversation"
 msgstr ""
 
-#: src/components/status.jsx:1299
+#: src/components/status.jsx:1297
 msgid "Unmute conversation"
 msgstr ""
 
-#: src/components/status.jsx:1306
+#: src/components/status.jsx:1304
 msgid "Mute conversation"
 msgstr ""
 
-#: src/components/status.jsx:1322
+#: src/components/status.jsx:1320
 msgid "Post unpinned from profile"
 msgstr ""
 
-#: src/components/status.jsx:1323
+#: src/components/status.jsx:1321
 msgid "Post pinned to profile"
 msgstr ""
 
-#: src/components/status.jsx:1328
+#: src/components/status.jsx:1326
 msgid "Unable to unpin post"
 msgstr ""
 
-#: src/components/status.jsx:1328
+#: src/components/status.jsx:1326
 msgid "Unable to pin post"
 msgstr ""
 
-#: src/components/status.jsx:1337
+#: src/components/status.jsx:1335
 msgid "Unpin from profile"
 msgstr ""
 
-#: src/components/status.jsx:1344
+#: src/components/status.jsx:1342
 msgid "Pin to profile"
 msgstr ""
 
-#: src/components/status.jsx:1373
+#: src/components/status.jsx:1371
 msgid "Delete this post?"
 msgstr ""
 
-#: src/components/status.jsx:1389
+#: src/components/status.jsx:1387
 msgid "Post deleted"
 msgstr ""
 
-#: src/components/status.jsx:1392
+#: src/components/status.jsx:1390
 msgid "Unable to delete post"
 msgstr ""
 
-#: src/components/status.jsx:1420
+#: src/components/status.jsx:1418
 msgid "Report post…"
 msgstr ""
 
 #. placeholder {6}: username || acct
-#: src/components/status.jsx:1490
+#: src/components/status.jsx:1488
 msgid "Unboosted @{6}'s post"
 msgstr "Unboosted @{6}'s post"
 
 #. placeholder {7}: username || acct
-#: src/components/status.jsx:1491
+#: src/components/status.jsx:1489
 msgid "Boosted @{7}'s post"
 msgstr "Boosted @{7}'s post"
 
-#: src/components/status.jsx:1776
-#: src/components/status.jsx:1812
-#: src/components/status.jsx:2506
+#: src/components/status.jsx:1774
+#: src/components/status.jsx:1810
+#: src/components/status.jsx:2504
 msgid "Liked"
 msgstr ""
 
-#: src/components/status.jsx:1809
-#: src/components/status.jsx:2493
+#: src/components/status.jsx:1807
+#: src/components/status.jsx:2491
 msgid "Boosted"
 msgstr ""
 
-#: src/components/status.jsx:1819
-#: src/components/status.jsx:2518
+#: src/components/status.jsx:1817
+#: src/components/status.jsx:2516
 msgid "Bookmarked"
 msgstr ""
 
-#: src/components/status.jsx:1823
+#: src/components/status.jsx:1821
 msgid "Pinned"
 msgstr ""
 
-#: src/components/status.jsx:1868
-#: src/components/status.jsx:2324
+#: src/components/status.jsx:1866
+#: src/components/status.jsx:2322
 msgid "Deleted"
 msgstr ""
 
-#: src/components/status.jsx:1909
+#: src/components/status.jsx:1907
 msgid "{repliesCount, plural, one {# reply} other {# replies}}"
 msgstr ""
 
 #. placeholder {0}: snapStates.statusThreadNumber[sKey] ? ` ${snapStates.statusThreadNumber[sKey]}/X` : ''
-#: src/components/status.jsx:1998
+#: src/components/status.jsx:1996
 msgid "Thread{0}"
 msgstr ""
 
-#: src/components/status.jsx:2074
-#: src/components/status.jsx:2136
-#: src/components/status.jsx:2221
+#: src/components/status.jsx:2072
+#: src/components/status.jsx:2134
+#: src/components/status.jsx:2219
 msgid "Show less"
 msgstr ""
 
-#: src/components/status.jsx:2074
-#: src/components/status.jsx:2136
+#: src/components/status.jsx:2072
+#: src/components/status.jsx:2134
 msgid "Show content"
 msgstr ""
 
-#: src/components/status.jsx:2221
+#: src/components/status.jsx:2219
 msgid "Show media"
 msgstr ""
 
-#: src/components/status.jsx:2358
+#: src/components/status.jsx:2356
 msgid "Edited"
 msgstr ""
 
-#: src/components/status.jsx:2435
+#: src/components/status.jsx:2433
 msgid "Comments"
 msgstr ""
 
 #. More from [Author]
-#: src/components/status.jsx:2744
+#: src/components/status.jsx:2742
 msgid "More from <0/>"
 msgstr "More from <0/>"
 
-#: src/components/status.jsx:3046
+#: src/components/status.jsx:3044
 msgid "Edit History"
 msgstr ""
 
-#: src/components/status.jsx:3050
+#: src/components/status.jsx:3048
 msgid "Failed to load history"
 msgstr ""
 
-#: src/components/status.jsx:3055
+#: src/components/status.jsx:3053
 #: src/pages/annual-report.jsx:45
 msgid "Loading…"
 msgstr ""
 
-#: src/components/status.jsx:3291
+#: src/components/status.jsx:3289
 msgid "HTML Code"
 msgstr ""
 
-#: src/components/status.jsx:3308
+#: src/components/status.jsx:3306
 msgid "HTML code copied"
 msgstr ""
 
-#: src/components/status.jsx:3311
+#: src/components/status.jsx:3309
 msgid "Unable to copy HTML code"
 msgstr ""
 
-#: src/components/status.jsx:3323
+#: src/components/status.jsx:3321
 msgid "Media attachments:"
 msgstr ""
 
-#: src/components/status.jsx:3345
+#: src/components/status.jsx:3343
 msgid "Account Emojis:"
 msgstr ""
 
-#: src/components/status.jsx:3376
-#: src/components/status.jsx:3421
+#: src/components/status.jsx:3374
+#: src/components/status.jsx:3419
 msgid "static URL"
 msgstr ""
 
-#: src/components/status.jsx:3390
+#: src/components/status.jsx:3388
 msgid "Emojis:"
 msgstr ""
 
-#: src/components/status.jsx:3435
+#: src/components/status.jsx:3433
 msgid "Notes:"
 msgstr ""
 
-#: src/components/status.jsx:3439
+#: src/components/status.jsx:3437
 msgid "This is static, unstyled and scriptless. You may need to apply your own styles and edit as needed."
 msgstr ""
 
-#: src/components/status.jsx:3445
+#: src/components/status.jsx:3443
 msgid "Polls are not interactive, becomes a list with vote counts."
 msgstr ""
 
-#: src/components/status.jsx:3450
+#: src/components/status.jsx:3448
 msgid "Media attachments can be images, videos, audios or any file types."
 msgstr ""
 
-#: src/components/status.jsx:3456
+#: src/components/status.jsx:3454
 msgid "Post could be edited or deleted later."
 msgstr ""
 
-#: src/components/status.jsx:3462
+#: src/components/status.jsx:3460
 msgid "Preview"
 msgstr ""
 
-#: src/components/status.jsx:3471
+#: src/components/status.jsx:3469
 msgid "Note: This preview is lightly styled."
 msgstr ""
 

--- a/src/locales/en.po
+++ b/src/locales/en.po
@@ -34,7 +34,7 @@ msgstr ""
 
 #: src/components/account-block.jsx:169
 #: src/components/account-info.jsx:641
-#: src/components/status.jsx:560
+#: src/components/status.jsx:557
 msgid "Group"
 msgstr ""
 
@@ -111,11 +111,11 @@ msgstr ""
 #: src/components/compose.jsx:2624
 #: src/components/media-alt-modal.jsx:46
 #: src/components/media-modal.jsx:358
-#: src/components/status.jsx:1783
-#: src/components/status.jsx:1800
-#: src/components/status.jsx:1924
+#: src/components/status.jsx:1780
+#: src/components/status.jsx:1797
+#: src/components/status.jsx:1921
+#: src/components/status.jsx:2533
 #: src/components/status.jsx:2536
-#: src/components/status.jsx:2539
 #: src/pages/account-statuses.jsx:527
 #: src/pages/accounts.jsx:110
 #: src/pages/hashtag.jsx:200
@@ -196,7 +196,7 @@ msgid "Original"
 msgstr ""
 
 #: src/components/account-info.jsx:864
-#: src/components/status.jsx:2314
+#: src/components/status.jsx:2311
 #: src/pages/catchup.jsx:71
 #: src/pages/catchup.jsx:1445
 #: src/pages/catchup.jsx:2058
@@ -293,30 +293,30 @@ msgid "Add/Remove from Lists"
 msgstr ""
 
 #: src/components/account-info.jsx:1304
-#: src/components/status.jsx:1223
+#: src/components/status.jsx:1220
 msgid "Link copied"
 msgstr ""
 
 #: src/components/account-info.jsx:1307
-#: src/components/status.jsx:1226
+#: src/components/status.jsx:1223
 msgid "Unable to copy link"
 msgstr ""
 
 #: src/components/account-info.jsx:1313
 #: src/components/shortcuts-settings.jsx:1059
-#: src/components/status.jsx:1232
-#: src/components/status.jsx:3315
+#: src/components/status.jsx:1229
+#: src/components/status.jsx:3312
 msgid "Copy"
 msgstr ""
 
 #: src/components/account-info.jsx:1328
 #: src/components/shortcuts-settings.jsx:1077
-#: src/components/status.jsx:1248
+#: src/components/status.jsx:1245
 msgid "Sharing doesn't seem to work."
 msgstr ""
 
 #: src/components/account-info.jsx:1334
-#: src/components/status.jsx:1254
+#: src/components/status.jsx:1251
 msgid "Share…"
 msgstr ""
 
@@ -435,9 +435,9 @@ msgstr ""
 #: src/components/shortcuts-settings.jsx:230
 #: src/components/shortcuts-settings.jsx:583
 #: src/components/shortcuts-settings.jsx:783
-#: src/components/status.jsx:3039
-#: src/components/status.jsx:3279
-#: src/components/status.jsx:3781
+#: src/components/status.jsx:3036
+#: src/components/status.jsx:3276
+#: src/components/status.jsx:3778
 #: src/pages/accounts.jsx:37
 #: src/pages/catchup.jsx:1581
 #: src/pages/filters.jsx:224
@@ -649,7 +649,7 @@ msgid "Attachment #{i} failed"
 msgstr "Attachment #{i} failed"
 
 #: src/components/compose.jsx:1180
-#: src/components/status.jsx:2109
+#: src/components/status.jsx:2106
 #: src/components/timeline.jsx:989
 msgid "Content warning"
 msgstr ""
@@ -685,7 +685,7 @@ msgstr ""
 
 #: src/components/compose.jsx:1247
 #: src/components/status.jsx:97
-#: src/components/status.jsx:1987
+#: src/components/status.jsx:1984
 msgid "Private mention"
 msgstr ""
 
@@ -714,10 +714,10 @@ msgstr ""
 
 #: src/components/compose.jsx:1555
 #: src/components/keyboard-shortcuts-help.jsx:152
-#: src/components/status.jsx:975
-#: src/components/status.jsx:1763
-#: src/components/status.jsx:1764
-#: src/components/status.jsx:2432
+#: src/components/status.jsx:972
+#: src/components/status.jsx:1760
+#: src/components/status.jsx:1761
+#: src/components/status.jsx:2429
 msgid "Reply"
 msgstr ""
 
@@ -949,7 +949,7 @@ msgstr ""
 
 #: src/components/drafts.jsx:128
 #: src/components/list-add-edit.jsx:186
-#: src/components/status.jsx:1398
+#: src/components/status.jsx:1395
 #: src/pages/filters.jsx:587
 msgid "Delete…"
 msgstr ""
@@ -1157,10 +1157,10 @@ msgid "<0>l</0> or <1>f</1>"
 msgstr ""
 
 #: src/components/keyboard-shortcuts-help.jsx:173
-#: src/components/status.jsx:983
-#: src/components/status.jsx:2459
-#: src/components/status.jsx:2490
-#: src/components/status.jsx:2491
+#: src/components/status.jsx:980
+#: src/components/status.jsx:2456
+#: src/components/status.jsx:2487
+#: src/components/status.jsx:2488
 msgid "Boost"
 msgstr ""
 
@@ -1169,9 +1169,9 @@ msgid "<0>Shift</0> + <1>b</1>"
 msgstr ""
 
 #: src/components/keyboard-shortcuts-help.jsx:181
-#: src/components/status.jsx:1068
-#: src/components/status.jsx:2515
-#: src/components/status.jsx:2516
+#: src/components/status.jsx:1065
+#: src/components/status.jsx:2512
+#: src/components/status.jsx:2513
 msgid "Bookmark"
 msgstr ""
 
@@ -1230,15 +1230,15 @@ msgid "Media description"
 msgstr ""
 
 #: src/components/media-alt-modal.jsx:58
-#: src/components/status.jsx:1112
-#: src/components/status.jsx:1139
+#: src/components/status.jsx:1109
+#: src/components/status.jsx:1136
 #: src/components/translation-block.jsx:196
 msgid "Translate"
 msgstr ""
 
 #: src/components/media-alt-modal.jsx:69
-#: src/components/status.jsx:1126
-#: src/components/status.jsx:1153
+#: src/components/status.jsx:1123
+#: src/components/status.jsx:1150
 msgid "Speak"
 msgstr ""
 
@@ -1275,9 +1275,9 @@ msgid "Filtered: {filterTitleStr}"
 msgstr ""
 
 #: src/components/media-post.jsx:134
-#: src/components/status.jsx:3611
-#: src/components/status.jsx:3707
-#: src/components/status.jsx:3785
+#: src/components/status.jsx:3608
+#: src/components/status.jsx:3704
+#: src/components/status.jsx:3782
 #: src/components/timeline.jsx:978
 #: src/pages/catchup.jsx:75
 #: src/pages/catchup.jsx:1877
@@ -1576,8 +1576,8 @@ msgid "[Unknown notification type: {type}]"
 msgstr ""
 
 #: src/components/notification.jsx:441
-#: src/components/status.jsx:1082
-#: src/components/status.jsx:1092
+#: src/components/status.jsx:1079
+#: src/components/status.jsx:1089
 msgid "Boosted/Liked by…"
 msgstr ""
 
@@ -1904,7 +1904,7 @@ msgid "Move down"
 msgstr ""
 
 #: src/components/shortcuts-settings.jsx:379
-#: src/components/status.jsx:1360
+#: src/components/status.jsx:1357
 #: src/pages/list.jsx:171
 msgid "Edit"
 msgstr ""
@@ -2103,315 +2103,319 @@ msgstr ""
 msgid "Import/export settings from/to instance server (Very experimental)"
 msgstr ""
 
-#: src/components/status.jsx:584
+#: src/components/status.jsx:469
+msgid "Thread muted"
+msgstr "Thread muted"
+
+#: src/components/status.jsx:581
 msgid "<0/> <1>boosted</1>"
 msgstr ""
 
-#: src/components/status.jsx:683
+#: src/components/status.jsx:680
 msgid "Sorry, your current logged-in instance can't interact with this post from another instance."
 msgstr ""
 
 #. placeholder {0}: username || acct
-#: src/components/status.jsx:836
+#: src/components/status.jsx:833
 msgid "Unliked @{0}'s post"
 msgstr ""
 
 #. placeholder {1}: username || acct
-#: src/components/status.jsx:837
+#: src/components/status.jsx:834
 msgid "Liked @{1}'s post"
 msgstr "Liked @{1}'s post"
 
 #. placeholder {2}: username || acct
-#: src/components/status.jsx:876
+#: src/components/status.jsx:873
 msgid "Unbookmarked @{2}'s post"
 msgstr "Unbookmarked @{2}'s post"
 
 #. placeholder {3}: username || acct
-#: src/components/status.jsx:877
+#: src/components/status.jsx:874
 msgid "Bookmarked @{3}'s post"
 msgstr "Bookmarked @{3}'s post"
 
-#: src/components/status.jsx:983
-#: src/components/status.jsx:1045
-#: src/components/status.jsx:2459
-#: src/components/status.jsx:2490
+#: src/components/status.jsx:980
+#: src/components/status.jsx:1042
+#: src/components/status.jsx:2456
+#: src/components/status.jsx:2487
 msgid "Unboost"
 msgstr ""
 
-#: src/components/status.jsx:999
-#: src/components/status.jsx:2474
+#: src/components/status.jsx:996
+#: src/components/status.jsx:2471
 msgid "Quote"
 msgstr ""
 
-#: src/components/status.jsx:1007
-#: src/components/status.jsx:2483
+#: src/components/status.jsx:1004
+#: src/components/status.jsx:2480
 msgid "Some media have no descriptions."
 msgstr ""
 
 #. placeholder {0}: rtf.format(-statusMonthsAgo, 'month')
-#: src/components/status.jsx:1014
+#: src/components/status.jsx:1011
 msgid "Old post (<0>{0}</0>)"
 msgstr ""
 
 #. placeholder {4}: username || acct
-#: src/components/status.jsx:1033
+#: src/components/status.jsx:1030
 msgid "Unboosted @{4}'s post"
 msgstr "Unboosted @{4}'s post"
 
 #. placeholder {5}: username || acct
-#: src/components/status.jsx:1034
+#: src/components/status.jsx:1031
 msgid "Boosted @{5}'s post"
 msgstr "Boosted @{5}'s post"
 
-#: src/components/status.jsx:1046
+#: src/components/status.jsx:1043
 msgid "Boost…"
 msgstr ""
 
-#: src/components/status.jsx:1058
-#: src/components/status.jsx:1773
-#: src/components/status.jsx:2503
+#: src/components/status.jsx:1055
+#: src/components/status.jsx:1770
+#: src/components/status.jsx:2500
 msgid "Unlike"
 msgstr ""
 
-#: src/components/status.jsx:1059
-#: src/components/status.jsx:1773
-#: src/components/status.jsx:1774
-#: src/components/status.jsx:2503
-#: src/components/status.jsx:2504
+#: src/components/status.jsx:1056
+#: src/components/status.jsx:1770
+#: src/components/status.jsx:1771
+#: src/components/status.jsx:2500
+#: src/components/status.jsx:2501
 msgid "Like"
 msgstr ""
 
-#: src/components/status.jsx:1068
-#: src/components/status.jsx:2515
+#: src/components/status.jsx:1065
+#: src/components/status.jsx:2512
 msgid "Unbookmark"
 msgstr ""
 
 #. placeholder {0}: username || acct
-#: src/components/status.jsx:1176
+#: src/components/status.jsx:1173
 msgid "View post by <0>@{0}</0>"
 msgstr ""
 
-#: src/components/status.jsx:1197
+#: src/components/status.jsx:1194
 msgid "Show Edit History"
 msgstr ""
 
-#: src/components/status.jsx:1200
+#: src/components/status.jsx:1197
 msgid "Edited: {editedDateText}"
 msgstr ""
 
-#: src/components/status.jsx:1267
-#: src/components/status.jsx:3284
+#: src/components/status.jsx:1264
+#: src/components/status.jsx:3281
 msgid "Embed post"
 msgstr ""
 
-#: src/components/status.jsx:1281
+#: src/components/status.jsx:1278
 msgid "Conversation unmuted"
 msgstr ""
 
-#: src/components/status.jsx:1281
+#: src/components/status.jsx:1278
 msgid "Conversation muted"
 msgstr ""
 
-#: src/components/status.jsx:1287
+#: src/components/status.jsx:1284
 msgid "Unable to unmute conversation"
 msgstr ""
 
-#: src/components/status.jsx:1288
+#: src/components/status.jsx:1285
 msgid "Unable to mute conversation"
 msgstr ""
 
-#: src/components/status.jsx:1297
+#: src/components/status.jsx:1294
 msgid "Unmute conversation"
 msgstr ""
 
-#: src/components/status.jsx:1304
+#: src/components/status.jsx:1301
 msgid "Mute conversation"
 msgstr ""
 
-#: src/components/status.jsx:1320
+#: src/components/status.jsx:1317
 msgid "Post unpinned from profile"
 msgstr ""
 
-#: src/components/status.jsx:1321
+#: src/components/status.jsx:1318
 msgid "Post pinned to profile"
 msgstr ""
 
-#: src/components/status.jsx:1326
+#: src/components/status.jsx:1323
 msgid "Unable to unpin post"
 msgstr ""
 
-#: src/components/status.jsx:1326
+#: src/components/status.jsx:1323
 msgid "Unable to pin post"
 msgstr ""
 
-#: src/components/status.jsx:1335
+#: src/components/status.jsx:1332
 msgid "Unpin from profile"
 msgstr ""
 
-#: src/components/status.jsx:1342
+#: src/components/status.jsx:1339
 msgid "Pin to profile"
 msgstr ""
 
-#: src/components/status.jsx:1371
+#: src/components/status.jsx:1368
 msgid "Delete this post?"
 msgstr ""
 
-#: src/components/status.jsx:1387
+#: src/components/status.jsx:1384
 msgid "Post deleted"
 msgstr ""
 
-#: src/components/status.jsx:1390
+#: src/components/status.jsx:1387
 msgid "Unable to delete post"
 msgstr ""
 
-#: src/components/status.jsx:1418
+#: src/components/status.jsx:1415
 msgid "Report post…"
 msgstr ""
 
 #. placeholder {6}: username || acct
-#: src/components/status.jsx:1488
+#: src/components/status.jsx:1485
 msgid "Unboosted @{6}'s post"
 msgstr "Unboosted @{6}'s post"
 
 #. placeholder {7}: username || acct
-#: src/components/status.jsx:1489
+#: src/components/status.jsx:1486
 msgid "Boosted @{7}'s post"
 msgstr "Boosted @{7}'s post"
 
-#: src/components/status.jsx:1774
-#: src/components/status.jsx:1810
-#: src/components/status.jsx:2504
+#: src/components/status.jsx:1771
+#: src/components/status.jsx:1807
+#: src/components/status.jsx:2501
 msgid "Liked"
 msgstr ""
 
-#: src/components/status.jsx:1807
-#: src/components/status.jsx:2491
+#: src/components/status.jsx:1804
+#: src/components/status.jsx:2488
 msgid "Boosted"
 msgstr ""
 
-#: src/components/status.jsx:1817
-#: src/components/status.jsx:2516
+#: src/components/status.jsx:1814
+#: src/components/status.jsx:2513
 msgid "Bookmarked"
 msgstr ""
 
-#: src/components/status.jsx:1821
+#: src/components/status.jsx:1818
 msgid "Pinned"
 msgstr ""
 
-#: src/components/status.jsx:1866
-#: src/components/status.jsx:2322
+#: src/components/status.jsx:1863
+#: src/components/status.jsx:2319
 msgid "Deleted"
 msgstr ""
 
-#: src/components/status.jsx:1907
+#: src/components/status.jsx:1904
 msgid "{repliesCount, plural, one {# reply} other {# replies}}"
 msgstr ""
 
 #. placeholder {0}: snapStates.statusThreadNumber[sKey] ? ` ${snapStates.statusThreadNumber[sKey]}/X` : ''
-#: src/components/status.jsx:1996
+#: src/components/status.jsx:1993
 msgid "Thread{0}"
 msgstr ""
 
-#: src/components/status.jsx:2072
-#: src/components/status.jsx:2134
-#: src/components/status.jsx:2219
+#: src/components/status.jsx:2069
+#: src/components/status.jsx:2131
+#: src/components/status.jsx:2216
 msgid "Show less"
 msgstr ""
 
-#: src/components/status.jsx:2072
-#: src/components/status.jsx:2134
+#: src/components/status.jsx:2069
+#: src/components/status.jsx:2131
 msgid "Show content"
 msgstr ""
 
-#: src/components/status.jsx:2219
+#: src/components/status.jsx:2216
 msgid "Show media"
 msgstr ""
 
-#: src/components/status.jsx:2356
+#: src/components/status.jsx:2353
 msgid "Edited"
 msgstr ""
 
-#: src/components/status.jsx:2433
+#: src/components/status.jsx:2430
 msgid "Comments"
 msgstr ""
 
 #. More from [Author]
-#: src/components/status.jsx:2742
+#: src/components/status.jsx:2739
 msgid "More from <0/>"
 msgstr "More from <0/>"
 
-#: src/components/status.jsx:3044
+#: src/components/status.jsx:3041
 msgid "Edit History"
 msgstr ""
 
-#: src/components/status.jsx:3048
+#: src/components/status.jsx:3045
 msgid "Failed to load history"
 msgstr ""
 
-#: src/components/status.jsx:3053
+#: src/components/status.jsx:3050
 #: src/pages/annual-report.jsx:45
 msgid "Loading…"
 msgstr ""
 
-#: src/components/status.jsx:3289
+#: src/components/status.jsx:3286
 msgid "HTML Code"
 msgstr ""
 
-#: src/components/status.jsx:3306
+#: src/components/status.jsx:3303
 msgid "HTML code copied"
 msgstr ""
 
-#: src/components/status.jsx:3309
+#: src/components/status.jsx:3306
 msgid "Unable to copy HTML code"
 msgstr ""
 
-#: src/components/status.jsx:3321
+#: src/components/status.jsx:3318
 msgid "Media attachments:"
 msgstr ""
 
-#: src/components/status.jsx:3343
+#: src/components/status.jsx:3340
 msgid "Account Emojis:"
 msgstr ""
 
-#: src/components/status.jsx:3374
-#: src/components/status.jsx:3419
+#: src/components/status.jsx:3371
+#: src/components/status.jsx:3416
 msgid "static URL"
 msgstr ""
 
-#: src/components/status.jsx:3388
+#: src/components/status.jsx:3385
 msgid "Emojis:"
 msgstr ""
 
-#: src/components/status.jsx:3433
+#: src/components/status.jsx:3430
 msgid "Notes:"
 msgstr ""
 
-#: src/components/status.jsx:3437
+#: src/components/status.jsx:3434
 msgid "This is static, unstyled and scriptless. You may need to apply your own styles and edit as needed."
 msgstr ""
 
-#: src/components/status.jsx:3443
+#: src/components/status.jsx:3440
 msgid "Polls are not interactive, becomes a list with vote counts."
 msgstr ""
 
-#: src/components/status.jsx:3448
+#: src/components/status.jsx:3445
 msgid "Media attachments can be images, videos, audios or any file types."
 msgstr ""
 
-#: src/components/status.jsx:3454
+#: src/components/status.jsx:3451
 msgid "Post could be edited or deleted later."
 msgstr ""
 
-#: src/components/status.jsx:3460
+#: src/components/status.jsx:3457
 msgid "Preview"
 msgstr ""
 
-#: src/components/status.jsx:3469
+#: src/components/status.jsx:3466
 msgid "Note: This preview is lightly styled."
 msgstr ""
 
 #. [Name] [Visibility icon] boosted
-#: src/components/status.jsx:3715
+#: src/components/status.jsx:3712
 msgid "<0/> <1/> boosted"
 msgstr ""
 

--- a/src/pages/settings.jsx
+++ b/src/pages/settings.jsx
@@ -680,6 +680,31 @@ function Settings({ onClose }) {
                 </small>
               </div>
             </li>
+            <li class="block">
+              <div class="sub-section">
+                <label>
+                  <Trans>
+                    Regex mutes
+                  </Trans>
+                </label>
+              </div>
+              <div class="sub-section">
+                <textarea
+                  value={snapStates.settings.regexFilter}
+                  onChange={(e) => {
+                    // FIXME: Probably inefficient
+                    states.settings.regexFilter = e.target.value;
+                  }}
+                />
+              </div>
+              <div class="sub-section insignificant">
+                <small>
+                  <Trans>
+                    Mute posts matching these regular expressions. One per line. Make sure that the final regular expression is terminated by a newline character, or it won't be parsed!
+                  </Trans>
+                </small>
+              </div>
+            </li>
             {authenticated && (
               <li>
                 <button

--- a/src/utils/states.js
+++ b/src/utils/states.js
@@ -71,6 +71,7 @@ const states = proxy({
     composerGIFPicker: false,
     cloakMode: false,
     groupedNotificationsAlpha: false,
+    regexFilter: "",
   },
 });
 
@@ -107,6 +108,8 @@ export function initStates() {
   states.settings.cloakMode = store.account.get('settings-cloakMode') ?? false;
   states.settings.groupedNotificationsAlpha =
     store.account.get('settings-groupedNotificationsAlpha') ?? false;
+  states.settings.regexFilter =
+    store.account.get('settings-regexFilter') ?? "";
 }
 
 subscribeKey(states, 'notificationsLast', (v) => {
@@ -158,6 +161,9 @@ subscribe(states, (changes) => {
     }
     if (path.join('.') === 'settings.groupedNotificationsAlpha') {
       store.account.set('settings-groupedNotificationsAlpha', !!value);
+    }
+    if (path.join('.') === 'settings.regexFilter') {
+      store.account.set('settings-regexFilter', states.settings.regexFilter);
     }
   }
 });


### PR DESCRIPTION
Another draft PR posted as per #777.

This is in a really bad state, as I quickly hacked it together just to see what was feasible and what was not, but it might be of interest for future, better implementations.

## Thread mutes

https://github.com/cheeaun/phanpy/labels/akkoma and https://github.com/cheeaun/phanpy/labels/pleroma collapse muted threads in the same way Phanpy filters posts, so the behavior is reproduced in Phanpy by checking for the `pleroma.threadMuted` property, and by spoofing a `filterInfo` object containing the title `Thread muted`.

![A muted thread in Akkoma.](https://github.com/user-attachments/assets/f284082f-05b1-400f-bb0d-c1a45999a63b "A collapsed post in Akkoma.")

![A muted thread in Phanpy with this patch.](https://github.com/user-attachments/assets/edef6230-1318-4865-9ded-20204c1c03ac)

## Add regex filtering

https://github.com/cheeaun/phanpy/labels/akkoma and https://github.com/cheeaun/phanpy/labels/pleroma do not implement server-side keyword filtering like Mastodon does, and instead rely on frontends to implement it themselves.

![](https://github.com/user-attachments/assets/4e64c1d8-15da-4fb8-9665-a3dbaafff302)

This patch implements very basic client-side filtering in Phanpy, by adding a textarea to Settings where the user can input their own regular expressions to filter, and then by matching those to the contents of each post, then spoofing a `filterInfo` object containing as title the first regex that matched.

![](https://github.com/user-attachments/assets/587af522-ede2-439e-8d1b-59e66312ee88)

![](https://github.com/user-attachments/assets/ed1ef63c-1068-449f-b272-0b39926cb739)

> [!Warning]
> 
> Since this creates new `RegExp` objects for each checked post, it probably is very inefficient; ideally, regular expressions should be compiled just once globally, and then just applied to each individual post.
