### PR TITLE
Increase global masto api timeout

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -42,7 +42,7 @@ export function initClient({ instance, accessToken }) {
   const masto = createRestAPIClient({
     url,
     accessToken, // Can be null
-    timeout: 30_000, // Unfortunatly this is global instead of per-request
+    timeout: 60_000, // Unfortunatly this is global instead of per-request
   });
 
   const client = {


### PR DESCRIPTION
I often encounter timeouts ("Fetch aborted" error message) when uploading images on poor connections. This looks like the place where the global timeout is configured. 