### PR TITLE
Changed CWs on replies to be kept if content is sensitive OR if there is spoiler text

### DIFF
--- a/src/components/compose.jsx
+++ b/src/components/compose.jsx
@@ -328,7 +328,7 @@ function Compose({
           prefs['posting:default:language']?.toLowerCase() ||
           DEFAULT_LANG,
       );
-      setSensitive(sensitive || spoilerText);
+      setSensitive(!!spoilerText);
     } else if (editStatus) {
       const { visibility, language, sensitive, poll, mediaAttachments } =
         editStatus;


### PR DESCRIPTION
This PR changes Phanpy's logic around whether the Content Warning field in the UI should be pre-filled with the CW from a toot you're replying to be _either_ if the `sensitive` flag is set _or_ if there is `spoiler_text` (a CW). This is to work around behaviour from clients like Tusky that set the `sensitive` flag back to false on replies with CWs when there isn't media attached.

Fixes #1110 (I described my investigation into this problem in that issue).