### PR TITLE
Potential fix for code scanning alert no. 38: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/custom-build.yml
+++ b/.github/workflows/custom-build.yml
@@ -1,4 +1,6 @@
 name: Custom Build
+permissions:
+  contents: read
 
 on:
   repository_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/cheeaun/phanpy/security/code-scanning/38](https://github.com/cheeaun/phanpy/security/code-scanning/38)

To address this issue, we need to add a `permissions` key to the workflow to restrict the default permissions granted to the GITHUB_TOKEN and thereby limit its access to repository resources. The best practice is to specify minimal required permissions at the top level of the workflow file (above the `jobs:` key), so it applies to all jobs unless locally overridden. Given the workflow only reads contents, a starting point of `contents: read` suffices. No existing functionality will be impacted—all steps will continue to work as before. Edit the `.github/workflows/custom-build.yml` file by inserting the following block:

```yaml
permissions:
  contents: read
```

directly after the workflow `name:` definition (line 1), and before any other blocks (such as `on:`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
