### PR TITLE
Update de-DE: Remove "post.title" from translations

### DIFF
--- a/src/locales/de-DE.po
+++ b/src/locales/de-DE.po
@@ -4362,7 +4362,7 @@ msgstr "HINWEIS: Push-Benachrichtigungen funktionieren nur für <0>ein Konto</0>
 #: src/pages/status.jsx:791
 #: src/pages/status.jsx:1465
 msgid "post.title"
-msgstr "post.title"
+msgstr ""
 
 #: src/pages/status.jsx:1068
 msgid "You're not logged in. Interactions (reply, boost, etc) are not possible."


### PR DESCRIPTION
Currently "post.title" is displayed in the German translation, instead it should fall back to the term "Post".