### PR TITLE
Update notifications.jsx to add '.' key Notifications refresh

### DIFF
--- a/src/locales/en.po
+++ b/src/locales/en.po
@@ -138,7 +138,7 @@ msgstr "Go to account page"
 #: src/components/timeline.jsx:656
 #: src/components/timeline2.jsx:685
 #: src/pages/home.jsx:243
-#: src/pages/notifications.jsx:1012
+#: src/pages/notifications.jsx:1032
 #: src/pages/status.jsx:1269
 #: src/pages/status.jsx:1745
 msgid "Try again"
@@ -306,7 +306,7 @@ msgstr "View post stats"
 #: src/pages/catchup.jsx:1731
 #: src/pages/filters.jsx:225
 #: src/pages/list.jsx:302
-#: src/pages/notifications.jsx:1056
+#: src/pages/notifications.jsx:1076
 #: src/pages/scheduled-posts.jsx:288
 #: src/pages/settings.jsx:104
 #: src/pages/status.jsx:1683
@@ -365,7 +365,7 @@ msgstr "More from <0/>"
 #: src/pages/followed-hashtags.jsx:41
 #: src/pages/home.jsx:61
 #: src/pages/home.jsx:69
-#: src/pages/notifications.jsx:689
+#: src/pages/notifications.jsx:709
 #: src/pages/scheduled-posts.jsx:74
 msgid "Home"
 msgstr ""
@@ -803,7 +803,7 @@ msgstr ""
 #: src/components/quote-settings-sheet.jsx:92
 #: src/components/shortcuts-settings.jsx:732
 #: src/pages/filters.jsx:572
-#: src/pages/notifications.jsx:1122
+#: src/pages/notifications.jsx:1142
 msgid "Save"
 msgstr ""
 
@@ -821,7 +821,7 @@ msgid "No featured profiles."
 msgstr "No featured profiles."
 
 #: src/components/follow-request-buttons.jsx:45
-#: src/pages/notifications.jsx:1106
+#: src/pages/notifications.jsx:1126
 msgid "Accept"
 msgstr ""
 
@@ -830,7 +830,7 @@ msgid "Reject"
 msgstr ""
 
 #: src/components/follow-request-buttons.jsx:79
-#: src/pages/notifications.jsx:1392
+#: src/pages/notifications.jsx:1412
 msgid "Accepted"
 msgstr ""
 
@@ -850,7 +850,7 @@ msgstr ""
 #: src/components/quotes-modal.jsx:129
 #: src/components/timeline.jsx:621
 #: src/pages/list.jsx:321
-#: src/pages/notifications.jsx:1036
+#: src/pages/notifications.jsx:1056
 #: src/pages/search.jsx:576
 #: src/pages/status.jsx:1716
 msgid "Show more…"
@@ -1411,7 +1411,7 @@ msgstr ""
 #: src/pages/home.jsx:255
 #: src/pages/mentions.jsx:25
 #: src/pages/mentions.jsx:256
-#: src/pages/notifications.jsx:913
+#: src/pages/notifications.jsx:933
 #: src/pages/settings.jsx:1295
 #: src/pages/trending.jsx:384
 msgid "Mentions"
@@ -1424,7 +1424,7 @@ msgstr ""
 #: src/pages/home.jsx:101
 #: src/pages/home.jsx:213
 #: src/pages/notifications.jsx:112
-#: src/pages/notifications.jsx:693
+#: src/pages/notifications.jsx:713
 msgid "Notifications"
 msgstr ""
 
@@ -3879,113 +3879,113 @@ msgstr ""
 msgid "Who are limited by server moderators"
 msgstr ""
 
-#: src/pages/notifications.jsx:707
-#: src/pages/notifications.jsx:1060
+#: src/pages/notifications.jsx:727
+#: src/pages/notifications.jsx:1080
 msgid "Notifications settings"
 msgstr ""
 
-#: src/pages/notifications.jsx:725
+#: src/pages/notifications.jsx:745
 msgid "New notifications"
 msgstr ""
 
 #. placeholder {0}: announcements.length
-#: src/pages/notifications.jsx:736
+#: src/pages/notifications.jsx:756
 msgid "{0, plural, one {Announcement} other {Announcements}}"
 msgstr ""
 
-#: src/pages/notifications.jsx:783
+#: src/pages/notifications.jsx:803
 #: src/pages/settings.jsx:1311
 msgid "Follow requests"
 msgstr ""
 
 #. placeholder {0}: followRequests.length
-#: src/pages/notifications.jsx:788
+#: src/pages/notifications.jsx:808
 msgid "{0, plural, one {# follow request} other {# follow requests}}"
 msgstr ""
 
 #. placeholder {0}: notificationsPolicy.summary.pendingRequestsCount
-#: src/pages/notifications.jsx:843
+#: src/pages/notifications.jsx:863
 msgid "{0, plural, one {Filtered notifications from # person} other {Filtered notifications from # people}}"
 msgstr ""
 
-#: src/pages/notifications.jsx:926
+#: src/pages/notifications.jsx:946
 msgid "Only mentions"
 msgstr ""
 
-#: src/pages/notifications.jsx:932
+#: src/pages/notifications.jsx:952
 msgid "Today"
 msgstr ""
 
-#: src/pages/notifications.jsx:937
+#: src/pages/notifications.jsx:957
 msgid "You're all caught up."
 msgstr ""
 
-#: src/pages/notifications.jsx:960
+#: src/pages/notifications.jsx:980
 msgid "Yesterday"
 msgstr ""
 
-#: src/pages/notifications.jsx:1008
+#: src/pages/notifications.jsx:1028
 msgid "Unable to load notifications"
 msgstr ""
 
-#: src/pages/notifications.jsx:1087
+#: src/pages/notifications.jsx:1107
 msgid "Notifications settings updated"
 msgstr ""
 
-#: src/pages/notifications.jsx:1095
+#: src/pages/notifications.jsx:1115
 msgid "Filter out notifications from people:"
 msgstr ""
 
-#: src/pages/notifications.jsx:1109
+#: src/pages/notifications.jsx:1129
 msgid "Filter"
 msgstr ""
 
-#: src/pages/notifications.jsx:1112
+#: src/pages/notifications.jsx:1132
 msgid "Ignore"
 msgstr ""
 
 #. placeholder {0}: niceDateTime(updatedAtDate)
-#: src/pages/notifications.jsx:1185
+#: src/pages/notifications.jsx:1205
 msgid "Updated <0>{0}</0>"
 msgstr ""
 
 #. placeholder {0}: account.username
-#: src/pages/notifications.jsx:1253
+#: src/pages/notifications.jsx:1273
 msgid "View notifications from <0>@{0}</0>"
 msgstr ""
 
 #. placeholder {0}: account.username
-#: src/pages/notifications.jsx:1274
+#: src/pages/notifications.jsx:1294
 msgid "Notifications from <0>@{0}</0>"
 msgstr ""
 
 #. placeholder {0}: request.account.username
-#: src/pages/notifications.jsx:1343
+#: src/pages/notifications.jsx:1363
 msgid "Notifications from @{0} will not be filtered from now on."
 msgstr ""
 
-#: src/pages/notifications.jsx:1348
+#: src/pages/notifications.jsx:1368
 msgid "Unable to accept notification request"
 msgstr ""
 
-#: src/pages/notifications.jsx:1353
+#: src/pages/notifications.jsx:1373
 msgid "Allow"
 msgstr ""
 
 #. placeholder {0}: request.account.username
-#: src/pages/notifications.jsx:1374
+#: src/pages/notifications.jsx:1394
 msgid "Notifications from @{0} will not show up in Filtered notifications from now on."
 msgstr "Notifications from @{0} will not show up in Filtered notifications from now on."
 
-#: src/pages/notifications.jsx:1379
+#: src/pages/notifications.jsx:1399
 msgid "Unable to dismiss notification request"
 msgstr ""
 
-#: src/pages/notifications.jsx:1384
+#: src/pages/notifications.jsx:1404
 msgid "Dismiss"
 msgstr ""
 
-#: src/pages/notifications.jsx:1399
+#: src/pages/notifications.jsx:1419
 msgid "Dismissed"
 msgstr ""
 

--- a/src/pages/notifications.jsx
+++ b/src/pages/notifications.jsx
@@ -658,9 +658,9 @@ function Notifications({ columnMode }) {
     {
       useKey: true,
       ignoreEventWhen: (e) => {
-        // Allow '.' even with Shift (some keyboard layouts require Shift for '.') 
-        if (e.key === '.') return false; 
-        return e.metaKey || e.ctrlKey || e.altKey || e.shiftKey; 
+        // Allow '.' even with Shift (some keyboard layouts require Shift for '.')
+        if (e.key === '.') return false;
+        return e.metaKey || e.ctrlKey || e.altKey || e.shiftKey;
       },
     },
   );

--- a/src/pages/notifications.jsx
+++ b/src/pages/notifications.jsx
@@ -658,9 +658,9 @@ function Notifications({ columnMode }) {
     {
       useKey: true,
       ignoreEventWhen: (e) => {
-        return (
-          e.metaKey || e.ctrlKey || e.altKey || e.shiftKey || e.key !== '.'
-        );
+        // Allow '.' even with Shift (some keyboard layouts require Shift for '.') 
+        if (e.key === '.') return false; 
+        return e.metaKey || e.ctrlKey || e.altKey || e.shiftKey; 
       },
     },
   );

--- a/src/pages/notifications.jsx
+++ b/src/pages/notifications.jsx
@@ -645,7 +645,7 @@ function Notifications({ columnMode }) {
       },
     },
   );
-  
+
   const dotRef = useHotkeys(
     '.',
     () => {
@@ -659,14 +659,10 @@ function Notifications({ columnMode }) {
       useKey: true,
       ignoreEventWhen: (e) => {
         return (
-          e.metaKey ||
-          e.ctrlKey ||
-          e.altKey ||
-          e.shiftKey ||
-          e.key !== '.'
+          e.metaKey || e.ctrlKey || e.altKey || e.shiftKey || e.key !== '.'
         );
-      }
-    }
+      },
+    },
   );
 
   const today = new Date();

--- a/src/pages/notifications.jsx
+++ b/src/pages/notifications.jsx
@@ -645,6 +645,29 @@ function Notifications({ columnMode }) {
       },
     },
   );
+  
+  const dotRef = useHotkeys(
+    '.',
+    () => {
+      loadNotifications(true);
+      scrollableRef.current?.scrollTo({
+        top: 0,
+        behavior: 'smooth',
+      });
+    },
+    {
+      useKey: true,
+      ignoreEventWhen: (e) => {
+        return (
+          e.metaKey ||
+          e.ctrlKey ||
+          e.altKey ||
+          e.shiftKey ||
+          e.key !== '.'
+        );
+      }
+    }
+  );
 
   const today = new Date();
   const todaySubHeading = useMemo(() => {
@@ -664,6 +687,7 @@ function Notifications({ columnMode }) {
         jRef.current = node;
         kRef.current = node;
         oRef.current = node;
+        dotRef.current = node;
       }}
       tabIndex="-1"
     >


### PR DESCRIPTION
This is just a key bind to trigger the code that is normally run when you click on the Notifications label to refresh. Now you can refresh your Notifications the same way as you would for the other columns in the multi-column Phanpy interface :-)