### PR TITLE
[codex] Add ATProto port fixes

### DIFF
--- a/ATPROTO_PORT_GOAL.md
+++ b/ATPROTO_PORT_GOAL.md
@@ -1,0 +1,59 @@
+# Goal: Port Phanpy to ATProto/Bluesky
+
+Port `/home/agent/phanpy` from Mastodon to ATProto/Bluesky, using `/home/agent/social-app` as the implementation reference.
+
+Goal: feature parity with upstream Phanpy where feasible, but as a fully client-side Bluesky client. V1 may use app-password auth; design the auth/session layer so OAuth can replace it later. Prioritize making the existing Phanpy UI work by translating Bluesky data into Phanpy's existing internal account/status/notification shapes at an adapter boundary.
+
+## Local Setup
+
+- Phanpy repo: `/home/agent/phanpy`
+- Bluesky social-app reference: `/home/agent/social-app`
+- Test credentials are stored in `/home/agent/.secrets/phanpy-atproto-test.env`
+- Current working dev loop:
+  - `cd /home/agent/phanpy`
+  - `npm run dev -- --host 127.0.0.1`
+  - app URL: `http://127.0.0.1:5173/`
+  - `npm test` passes after switching Playwright to Nix Chromium
+- Use Chromium only. System Chromium is `/run/current-system/sw/bin/chromium`.
+- Use `agent-browser` for browser/UI smoke checks.
+
+## Current Changes
+
+- `/home/agent/phanpy/playwright.config.js` points Playwright at Nix Chromium.
+- `package-lock.json` has npm metadata churn from `npm install`; inspect before committing.
+
+## Implementation Strategy
+
+1. Add `@atproto/api` to Phanpy if needed.
+2. Create ATProto client/session module, app-password login, persisted account/session storage.
+3. Add a Bluesky-to-Phanpy adapter layer:
+   - actor profile -> Phanpy account shape
+   - post view / feed item -> Phanpy status shape
+   - notifications -> Phanpy notification/groupable shape
+   - embeds/images/video/external/record -> existing media/card/quote fields where possible
+4. Replace Mastodon API calls incrementally behind the existing `api()` boundary or a nearby adapter, keeping UI components mostly intact.
+5. First vertical slice: login -> authenticated home timeline -> post detail/thread -> like/repost/bookmark/quote/reply smoke tested.
+6. Then add profiles, search, notifications, lists, bookmarks, moderation/report/block/mute.
+7. Hashtags exist in Bluesky but are low priority.
+
+## Feed Switching
+
+Support switching between Bluesky feeds. This includes the main following timeline, Discover/official feeds, saved custom feeds, user-created or third-party feed generators, and list feeds where Phanpy's shortcut/multi-column model can map to them.
+
+Use social-app's feed APIs as reference: `FollowingFeedAPI`, `CustomFeedAPI`, `ListFeedAPI`, `HomeFeedAPI`, saved feeds/preferences, and feed generator resolution. The UX should preserve Phanpy's shortcuts/columns concept while backing each shortcut with a Bluesky feed descriptor.
+
+## Key Decisions
+
+- Preserve Phanpy's internal data model at UI boundaries.
+- Use AT URI as canonical post ID; introduce URL-safe route encoding/decoding for post routes.
+- Keep pure client-side/static deployment.
+- Do not fork social-app UI. Use it as API behavior/reference only.
+- Keep changes tight and smoke test often.
+
+## Verification Expectations
+
+- Prioritize E2E and smoke tests over unit tests. Unit tests are useful support, but the main confidence loop is real user flows in the browser.
+- Keep `npm test` green.
+- Use `agent-browser` against local Vite server for logged-out and logged-in smoke tests.
+- Use the saved test account only from env file; do not print credentials.
+- Build should pass before stopping if feasible.

--- a/index.html
+++ b/index.html
@@ -16,6 +16,16 @@
       :root {
         color-scheme: light dark;
       }
+
+      #boot-status {
+        padding: 24px;
+        font-family:
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          sans-serif;
+        color: CanvasText;
+      }
     </style>
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
@@ -51,8 +61,31 @@
     <link rel="me" href="https://hachyderm.io/@phanpy" />
   </head>
   <body>
-    <div id="app"></div>
+    <div id="app">
+      <div id="boot-status">Loading Phanpy...</div>
+    </div>
     <div id="modal-container"></div>
+    <script>
+      window.addEventListener('error', (event) => {
+        const bootStatus = document.getElementById('boot-status');
+        if (bootStatus) {
+          bootStatus.textContent = `Phanpy failed to start: ${event.message || 'unknown error'}`;
+        }
+      });
+      window.addEventListener('unhandledrejection', (event) => {
+        const bootStatus = document.getElementById('boot-status');
+        if (bootStatus) {
+          bootStatus.textContent = `Phanpy failed to start: ${event.reason?.message || event.reason || 'unknown error'}`;
+        }
+      });
+      window.setTimeout(() => {
+        const bootStatus = document.getElementById('boot-status');
+        if (bootStatus) {
+          bootStatus.textContent =
+            'Phanpy is still loading. If this stays here, Safari did not run the app script.';
+        }
+      }, 5000);
+    </script>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@atproto/api": "^0.19.15",
         "@formatjs/intl-localematcher": "~0.8.2",
         "@formatjs/intl-segmenter": "~12.2.1",
         "@formkit/auto-animate": "~0.9.0",
@@ -122,6 +123,88 @@
         "ajv": ">=8"
       }
     },
+    "node_modules/@atproto/api": {
+      "version": "0.19.15",
+      "resolved": "https://registry.npmjs.org/@atproto/api/-/api-0.19.15.tgz",
+      "integrity": "sha512-MDXZIEJS8iksqEYa6W6Bz0gpe6aDnHDiZUymFFvzTCqWShCCbmefv3O07GgwSqLINoAuCUKJUZWkq20wR8fa9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/common-web": "^0.4.21",
+        "@atproto/lexicon": "^0.6.2",
+        "@atproto/syntax": "^0.5.4",
+        "@atproto/xrpc": "^0.7.7",
+        "await-lock": "^2.2.2",
+        "multiformats": "^9.9.0",
+        "tlds": "^1.234.0",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@atproto/common-web": {
+      "version": "0.4.21",
+      "resolved": "https://registry.npmjs.org/@atproto/common-web/-/common-web-0.4.21.tgz",
+      "integrity": "sha512-Odq+wdk3YNasGCjjlpl3bCIPvqYHige5DLfMkIffNv/2PI/iIj5ZvAvMvJlJ59OhReKSxtpI0invx5UQPc3+fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/lex-data": "^0.0.15",
+        "@atproto/lex-json": "^0.0.16",
+        "@atproto/syntax": "^0.5.4",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@atproto/lex-data": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-data/-/lex-data-0.0.15.tgz",
+      "integrity": "sha512-ZsbGiaM5S3CnGrcTMbDGON3bLZzCi/Mx9UvcMREKSRujnF68eHgMiXxJqvykP7+QpOX6tYCK93axZkuJVhtSEw==",
+      "license": "MIT",
+      "dependencies": {
+        "multiformats": "^9.9.0",
+        "tslib": "^2.8.1",
+        "uint8arrays": "3.0.0",
+        "unicode-segmenter": "^0.14.0"
+      }
+    },
+    "node_modules/@atproto/lex-json": {
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-json/-/lex-json-0.0.16.tgz",
+      "integrity": "sha512-IgLgQ0krshVlrIYZ+heTBDbCnM3LmAgWvsaYn5MxvKA3LcBot3PG3ptdO8VOweVZ+WgCLuo39cz9EbUmIbqdtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/lex-data": "^0.0.15",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@atproto/lexicon": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@atproto/lexicon/-/lexicon-0.6.2.tgz",
+      "integrity": "sha512-p3Ly6hinVZW0ETuAXZMeUGwuMm3g8HvQMQ41yyEE6AL0hAkfeKFaZKos6BdBrr6CjkpbrDZqE8M+5+QOceysMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/common-web": "^0.4.18",
+        "@atproto/syntax": "^0.5.0",
+        "iso-datestring-validator": "^2.2.2",
+        "multiformats": "^9.9.0",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@atproto/syntax": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@atproto/syntax/-/syntax-0.5.4.tgz",
+      "integrity": "sha512-9XJOpMAgsGFxMEIp8nJ8AIWv+krrY1xQMj+wULbbXhQztQV+9aZ0TbG9Jtn3Op2or8Kr6OqyWR4ga9Z189kKDw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@atproto/xrpc": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/@atproto/xrpc/-/xrpc-0.7.7.tgz",
+      "integrity": "sha512-K1ZyO/BU8JNtXX5dmPp7b5UrkLMMqpsIa/Lrj5D3Su+j1Xwq1m6QJ2XJ1AgjEjkI1v4Muzm7klianLE6XGxtmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/lexicon": "^0.6.0",
+        "zod": "^3.23.8"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
       "devOptional": true,
@@ -147,7 +230,6 @@
       "version": "7.28.5",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1614,7 +1696,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1636,7 +1717,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -2796,7 +2876,6 @@
       "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -2808,7 +2887,6 @@
       "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -3446,7 +3524,6 @@
       "version": "5.9.5",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.20.12",
         "@babel/runtime": "^7.20.13",
@@ -4646,7 +4723,6 @@
       "version": "8.17.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -4805,6 +4881,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/await-lock": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/await-lock/-/await-lock-2.2.2.tgz",
+      "integrity": "sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==",
+      "license": "MIT"
+    },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.4.14",
       "dev": true,
@@ -4944,7 +5026,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6924,6 +7005,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/iso-datestring-validator": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/iso-datestring-validator/-/iso-datestring-validator-2.2.2.tgz",
+      "integrity": "sha512-yLEMkBbLZTlVQqOnQ4FiMujR6T4DEcCb1xizmvXS+OxuhwcbtynoosRzdMA69zZCShCNAbi+gJ71FxZBBXx1SA==",
+      "license": "MIT"
+    },
     "node_modules/isomorphic-ws": {
       "version": "5.0.0",
       "license": "MIT",
@@ -7541,6 +7628,12 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+      "license": "(Apache-2.0 AND MIT)"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "dev": true,
@@ -8002,7 +8095,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -8697,7 +8789,6 @@
       "version": "7.1.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -8725,7 +8816,6 @@
     "node_modules/preact": {
       "version": "10.29.1",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -8770,7 +8860,6 @@
       "version": "15.8.1",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -9208,6 +9297,7 @@
     "node_modules/scheduler": {
       "version": "0.23.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -9724,7 +9814,6 @@
       "version": "5.44.1",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -9812,7 +9901,6 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9840,6 +9928,15 @@
       "license": "MIT",
       "engines": {
         "node": "^20.0.0 || >=22.0.0"
+      }
+    },
+    "node_modules/tlds": {
+      "version": "1.261.0",
+      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.261.0.tgz",
+      "integrity": "sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA==",
+      "license": "MIT",
+      "bin": {
+        "tlds": "bin.js"
       }
     },
     "node_modules/to-regex-range": {
@@ -9992,6 +10089,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/uint8arrays": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
+      "integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
+      "license": "MIT",
+      "dependencies": {
+        "multiformats": "^9.4.2"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "dev": true,
@@ -10049,6 +10155,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/unicode-segmenter": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/unicode-segmenter/-/unicode-segmenter-0.14.5.tgz",
+      "integrity": "sha512-jHGmj2LUuqDcX3hqY12Ql+uhUTn8huuxNZGq7GvtF6bSybzH3aFgedYu/KTzQStEgt1Ra2F3HxadNXsNjb3m3g==",
+      "license": "MIT"
     },
     "node_modules/unique-string": {
       "version": "2.0.0",
@@ -10166,7 +10278,6 @@
       "version": "8.0.8",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -10645,7 +10756,6 @@
       "version": "2.79.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -10851,7 +10961,6 @@
     "node_modules/ws": {
       "version": "8.18.3",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -10892,6 +11001,15 @@
       "version": "1.1.4",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "generate-icons": "node scripts/generate-icons.js"
   },
   "dependencies": {
+    "@atproto/api": "^0.19.15",
     "@formatjs/intl-localematcher": "~0.8.2",
     "@formatjs/intl-segmenter": "~12.2.1",
     "@formkit/auto-animate": "~0.9.0",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -7,6 +7,9 @@ console.warn = () => {};
 console.info = () => {};
 console.debug = () => {};
 
+const DEV_PORT = Number(process.env.PORT || process.env.VITE_PORT) || 5173;
+const BASE_URL = `http://localhost:${DEV_PORT}`;
+
 /**
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
@@ -33,7 +36,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://localhost:5173',
+    baseURL: BASE_URL,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -42,15 +45,22 @@ export default defineConfig({
   /* Configure projects for major browsers */
   projects: [
     {
-      name: 'Mobile Safari',
-      use: { ...devices['iPhone 13 Mini'] },
+      name: 'Chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        launchOptions: {
+          executablePath:
+            process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH ||
+            '/run/current-system/sw/bin/chromium',
+        },
+      },
     },
   ],
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'npm run dev',
-    url: 'http://localhost:5173',
+    command: `npm run dev -- --port ${DEV_PORT}`,
+    url: BASE_URL,
     reuseExistingServer: !process.env.CI,
   },
 });

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -611,11 +611,7 @@ function App() {
 
   // Signal to service worker that this client is ready to receive share data
   useEffect(() => {
-    if (
-      'serviceWorker' in navigator &&
-      (isPWA || import.meta.env.DEV) &&
-      uiState === 'default'
-    ) {
+    if ('serviceWorker' in navigator && isPWA && uiState === 'default') {
       navigator.serviceWorker
         .getRegistration()
         .then(function (registration) {
@@ -672,13 +668,29 @@ function isRootPath(pathname) {
 
 const PrimaryRoutes = memo(() => {
   const location = useLocation();
-  const nonRootLocation = useMemo(() => {
+  const primaryLocation = useMemo(() => {
     const { pathname } = location;
-    return !isRootPath(pathname);
+    if (pathname === '/' || isRootPath(pathname)) return location;
+
+    const isModalPage =
+      matchPath('/:instance/s/:id', pathname) || matchPath('/s/:id', pathname);
+    const prevLocation = states.prevLocation;
+    if (
+      isModalPage &&
+      (!prevLocation ||
+        prevLocation.pathname === '/' ||
+        isRootPath(prevLocation.pathname))
+    ) {
+      return prevLocation || { ...location, pathname: '/' };
+    }
+
+    return null;
   }, [location]);
 
+  if (!primaryLocation) return null;
+
   return (
-    <Routes location={nonRootLocation || location}>
+    <Routes location={primaryLocation}>
       <Route path="/" element={<Root />} />
       <Route path="/login" element={<Login />} />
       <Route path="/welcome" element={<Welcome />} />

--- a/src/components/account-info.jsx
+++ b/src/components/account-info.jsx
@@ -504,7 +504,11 @@ function AccountInfo({
                       e.target.remove();
                     }
                   }}
-                  crossOrigin="anonymous"
+                  crossOrigin={
+                    /\/\/cdn\.bsky\.app\//.test(header)
+                      ? undefined
+                      : 'anonymous'
+                  }
                   onLoad={(e) => {
                     e.target.classList.add('loaded');
                     const { width, height } = e.target;

--- a/src/components/add-remove-lists-sheet.jsx
+++ b/src/components/add-remove-lists-sheet.jsx
@@ -2,7 +2,7 @@ import { Trans, useLingui } from '@lingui/react/macro';
 import { useEffect, useReducer, useState } from 'preact/hooks';
 
 import { api } from '../utils/api';
-import { getLists } from '../utils/lists';
+import { getUserLists } from '../utils/lists';
 
 import Icon from './icon';
 import ListAddEdit from './list-add-edit';
@@ -21,7 +21,7 @@ function AddRemoveListsSheet({ accountID, onClose }) {
     setUIState('loading');
     (async () => {
       try {
-        const lists = await getLists();
+        const lists = await getUserLists();
         setLists(lists);
         const listsContainingAccount = await masto.v1.accounts
           .$select(accountID)

--- a/src/components/avatar.jsx
+++ b/src/components/avatar.jsx
@@ -38,6 +38,7 @@ function Avatar({ url, staticUrl, size, alt = '', squircle, ...props }) {
   size = SIZES[size] || size || SIZES.m;
   const avatarRef = useRef();
   const isMissing = MISSING_IMAGE_PATH_REGEX.test(url);
+  const canCheckAlpha = url && !/\/\/cdn\.bsky\.app\//.test(url);
   return (
     <picture
       ref={avatarRef}
@@ -64,7 +65,9 @@ function Avatar({ url, staticUrl, size, alt = '', squircle, ...props }) {
           decoding="async"
           fetchPriority="low"
           crossOrigin={
-            !alphaCache.has(url) && !isMissing ? 'anonymous' : undefined
+            canCheckAlpha && !alphaCache.has(url) && !isMissing
+              ? 'anonymous'
+              : undefined
           }
           onError={(e) => {
             if (e.target.crossOrigin) {
@@ -76,6 +79,7 @@ function Avatar({ url, staticUrl, size, alt = '', squircle, ...props }) {
             if (avatarRef.current) avatarRef.current.dataset.loaded = true;
             if (alphaCache.has(url)) return;
             if (isMissing) return;
+            if (!canCheckAlpha) return;
             scheduleTask(() => {
               try {
                 // Check if image has alpha channel

--- a/src/components/compose-button.jsx
+++ b/src/components/compose-button.jsx
@@ -53,7 +53,7 @@ export default function ComposeButton() {
   const buttonRef = useRef(null);
   const menuRef = useRef(null);
 
-  const columnMode = snapStates.settings.shortcutsViewMode === 'multi-column';
+  const columnMode = false;
 
   function handleButton(e) {
     // useKey will even listen to Shift

--- a/src/components/compose.jsx
+++ b/src/components/compose.jsx
@@ -1026,7 +1026,8 @@ function Compose({
     },
   });
 
-  const showScheduledAt = !editStatus;
+  const showScheduledAt =
+    !editStatus && currentAccount?.instanceURL !== 'bsky.social';
   const scheduledAtButtonDisabled = uiState === 'loading' || !!scheduledAt;
   const onScheduledAtClick = () => {
     const date = new Date(Date.now() + DEFAULT_SCHEDULED_AT);

--- a/src/components/keyboard-shortcuts-help.jsx
+++ b/src/components/keyboard-shortcuts-help.jsx
@@ -120,22 +120,6 @@ export default memo(function KeyboardShortcutsHelp() {
                     ),
                   },
                   {
-                    action: t`Focus column in multi-column mode`,
-                    keys: (
-                      <Trans>
-                        <kbd>1</kbd> to <kbd>9</kbd>
-                      </Trans>
-                    ),
-                  },
-                  {
-                    action: t`Focus next column in multi-column mode`,
-                    keys: <kbd>]</kbd>,
-                  },
-                  {
-                    action: t`Focus previous column in multi-column mode`,
-                    keys: <kbd>[</kbd>,
-                  },
-                  {
                     action: t`Compose new post`,
                     keys: <kbd>c</kbd>,
                   },

--- a/src/components/nav-menu.jsx
+++ b/src/components/nav-menu.jsx
@@ -1,14 +1,19 @@
 import './nav-menu.css';
 
 import { Trans, useLingui } from '@lingui/react/macro';
-import { ControlledMenu, MenuDivider, MenuItem } from '@szhsin/react-menu';
+import {
+  ControlledMenu,
+  MenuDivider,
+  MenuHeader,
+  MenuItem,
+} from '@szhsin/react-menu';
 import { memo } from 'preact/compat';
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import { useLongPress } from 'use-long-press';
 import { useSnapshot } from 'valtio';
 
 import { api } from '../utils/api';
-import { getLists } from '../utils/lists';
+import { getLists, splitListsAndFeeds } from '../utils/lists';
 import safeBoundingBoxPadding from '../utils/safe-bounding-box-padding';
 import states from '../utils/states';
 import store from '../utils/store';
@@ -40,15 +45,7 @@ function NavMenu(props) {
     snapStates.shortcuts.some((pin) => pin.type === 'profile');
   const showAvatarInButton = moreThanOneAccount && !tabMenuHasProfile;
 
-  // Home = Following
-  // But when in multi-column mode, Home becomes columns of anything
-  // User may choose pin or not to pin Following
-  // If user doesn't pin Following, we show it in the menu
-  const showFollowing =
-    (snapStates.settings.shortcutsViewMode === 'multi-column' ||
-      (!snapStates.settings.shortcutsViewMode &&
-        snapStates.settings.shortcutsColumnsMode)) &&
-    !snapStates.shortcuts.find((pin) => pin.type === 'following');
+  const showFollowing = authenticated;
 
   const bindLongPress = useLongPress(
     () => {
@@ -381,7 +378,7 @@ function NavMenu(props) {
               >
                 <Icon icon="shortcut" size="l" />{' '}
                 <span>
-                  <Trans>Shortcuts / Columns…</Trans>
+                  <Trans>Shortcuts…</Trans>
                 </span>
               </MenuItem>
               <MenuItem
@@ -419,6 +416,7 @@ function NavMenu(props) {
 function ListMenu({ menuState }) {
   const supportsLists = supports('@mastodon/lists');
   const [lists, setLists] = useState([]);
+  const { lists: userLists, feeds } = splitListsAndFeeds(lists);
   useEffect(() => {
     if (!supportsLists) return;
     if (menuState === 'open') {
@@ -428,14 +426,14 @@ function ListMenu({ menuState }) {
 
   return lists.length > 0 ? (
     <SubMenu2
-      menuClassName="nav-submenu"
+      menuClassName="nav-submenu lists-picker-menu"
       overflow="auto"
       gap={-8}
       label={
         <>
           <Icon icon="list" size="l" />
           <span class="menu-grow">
-            <Trans>Lists</Trans>
+            <Trans>Lists & Feeds</Trans>
           </span>
           <Icon icon="chevron-right" />
         </>
@@ -443,25 +441,44 @@ function ListMenu({ menuState }) {
     >
       <MenuLink to="/l">
         <span>
-          <Trans>All Lists</Trans>
+          <Trans>Lists & Feeds</Trans>
         </span>
       </MenuLink>
-      {lists?.length > 0 && (
+      {(userLists.length > 0 || feeds.length > 0) && (
         <>
           <MenuDivider />
-          {lists.map((list) => (
-            <MenuLink key={list.id} to={`/l/${list.id}`}>
-              <span>
-                {list.title}
-                {list.exclusive && (
-                  <>
-                    {' '}
-                    <ListExclusiveBadge />
-                  </>
-                )}
-              </span>
-            </MenuLink>
-          ))}
+          {userLists.length > 0 && (
+            <>
+              <MenuHeader className="plain">
+                <Trans>Lists</Trans>
+              </MenuHeader>
+              {userLists.map((list) => (
+                <MenuLink key={list.id} to={`/l/${list.id}`}>
+                  <span>
+                    {list.title}
+                    {list.exclusive && (
+                      <>
+                        {' '}
+                        <ListExclusiveBadge />
+                      </>
+                    )}
+                  </span>
+                </MenuLink>
+              ))}
+            </>
+          )}
+          {feeds.length > 0 && (
+            <>
+              <MenuHeader className="plain">
+                <Trans>Feeds</Trans>
+              </MenuHeader>
+              {feeds.map((feed) => (
+                <MenuLink key={feed.id} to={`/l/${feed.id}`}>
+                  <Icon icon="sparkles" /> <span>{feed.title}</span>
+                </MenuLink>
+              ))}
+            </>
+          )}
         </>
       )}
     </SubMenu2>
@@ -470,7 +487,7 @@ function ListMenu({ menuState }) {
       <MenuLink to="/l">
         <Icon icon="list" size="l" />
         <span>
-          <Trans>Lists</Trans>
+          <Trans>Lists & Feeds</Trans>
         </span>
       </MenuLink>
     )

--- a/src/components/shortcuts-settings.jsx
+++ b/src/components/shortcuts-settings.jsx
@@ -11,12 +11,11 @@ import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import { useSnapshot } from 'valtio';
 
 import floatingButtonUrl from '../assets/floating-button.svg';
-import multiColumnUrl from '../assets/multi-column.svg';
 import tabMenuBarUrl from '../assets/tab-menu-bar.svg';
 
 import { api } from '../utils/api';
 import { fetchFollowedTags } from '../utils/followed-tags';
-import { getLists, getListTitle } from '../utils/lists';
+import { getLists, getListTitle, splitListsAndFeeds } from '../utils/lists';
 import pmem from '../utils/pmem';
 import showToast from '../utils/show-toast';
 import states from '../utils/states';
@@ -49,7 +48,7 @@ const TYPES = [
 const TYPE_TEXT = {
   following: msg`Home / Following`,
   notifications: msg`Notifications`,
-  list: msg`Lists`,
+  list: msg`Lists & Feeds`,
   public: msg`Public (Local / Federated)`,
   search: msg`Search`,
   'account-statuses': msg`Account`,
@@ -96,7 +95,7 @@ const TYPE_PARAMS = {
       text: msg`Search term`,
       name: 'query',
       type: 'text',
-      placeholder: msg`Optional, unless for multi-column mode`,
+      placeholder: msg`Optional`,
       notRequired: true,
     },
   ],
@@ -158,10 +157,9 @@ export const SHORTCUTS_META = {
   },
   list: {
     id: ({ id }) => (id ? 'list' : 'lists'),
-    title: ({ id }) => (id ? getListTitle(id) : t`Lists`),
+    title: ({ id }) => (id ? getListTitle(id) : t`Lists & Feeds`),
     path: ({ id }) => (id ? `/l/${id}` : '/l'),
     icon: 'list',
-    excludeViewMode: ({ id }) => (!id ? ['multi-column'] : []),
   },
   public: {
     id: 'public',
@@ -185,7 +183,6 @@ export const SHORTCUTS_META = {
         ? `/search?q=${encodeURIComponent(query)}&type=statuses`
         : '/search',
     icon: 'search',
-    excludeViewMode: ({ query }) => (!query ? ['multi-column'] : []),
   },
   profile: {
     id: 'profile',
@@ -276,11 +273,6 @@ function ShortcutsSettings({ onClose }) {
               value: 'tab-menu-bar',
               label: t`Tab/Menu bar`,
               imgURL: tabMenuBarUrl,
-            },
-            {
-              value: 'multi-column',
-              label: t`Multi-column`,
-              imgURL: multiColumnUrl,
             },
           ].map(({ value, label, imgURL }) => {
             const checked =
@@ -423,11 +415,7 @@ function ShortcutsSettings({ onClose }) {
           </>
         ) : (
           <div class="ui-state insignificant">
-            <p>
-              {snapStates.settings.shortcutsViewMode === 'multi-column'
-                ? t`No columns yet. Tap on the Add column button.`
-                : t`No shortcuts yet. Tap on the Add shortcut button.`}
-            </p>
+            <p>{t`No shortcuts yet. Tap on the Add shortcut button.`}</p>
             <p>
               <Trans>
                 Not sure what to add?
@@ -456,9 +444,7 @@ function ShortcutsSettings({ onClose }) {
         )}
         <p class="insignificant">
           {shortcuts.length >= SHORTCUTS_LIMIT &&
-            (snapStates.settings.shortcutsViewMode === 'multi-column'
-              ? t`Max ${SHORTCUTS_LIMIT} columns`
-              : t`Max ${SHORTCUTS_LIMIT} shortcuts`)}
+            t`Max ${SHORTCUTS_LIMIT} shortcuts`}
         </p>
         <p
           style={{
@@ -479,12 +465,7 @@ function ShortcutsSettings({ onClose }) {
             disabled={shortcuts.length >= SHORTCUTS_LIMIT}
             onClick={() => setShowForm(true)}
           >
-            <Icon icon="plus" />{' '}
-            <span>
-              {snapStates.settings.shortcutsViewMode === 'multi-column'
-                ? t`Add column…`
-                : t`Add shortcut…`}
-            </span>
+            <Icon icon="plus" /> <span>{t`Add shortcut…`}</span>
           </button>
         </p>
       </main>
@@ -530,8 +511,7 @@ function ShortcutsSettings({ onClose }) {
 }
 
 const FORM_NOTES = {
-  list: msg`Specific list is optional. For multi-column mode, list is required, else the column will not be shown.`,
-  search: msg`For multi-column mode, search term is required, else the column will not be shown.`,
+  list: msg`Specific list is optional.`,
   hashtag: msg`Multiple hashtags are supported. Space-separated.`,
 };
 
@@ -549,6 +529,7 @@ function ShortcutForm({
 
   const [uiState, setUIState] = useState('default');
   const [lists, setLists] = useState([]);
+  const { lists: userLists, feeds } = splitListsAndFeeds(lists);
   const [followedHashtags, setFollowedHashtags] = useState([]);
   useEffect(() => {
     (async () => {
@@ -673,9 +654,20 @@ function ShortcutForm({
                         dir="auto"
                       >
                         <option value=""></option>
-                        {lists.map((list) => (
-                          <option value={list.id}>{list.title}</option>
-                        ))}
+                        {userLists.length > 0 && (
+                          <optgroup label={t`Lists`}>
+                            {userLists.map((list) => (
+                              <option value={list.id}>{list.title}</option>
+                            ))}
+                          </optgroup>
+                        )}
+                        {feeds.length > 0 && (
+                          <optgroup label={t`Feeds`}>
+                            {feeds.map((feed) => (
+                              <option value={feed.id}>{feed.title}</option>
+                            ))}
+                          </optgroup>
+                        )}
                       </select>
                     </label>
                   </p>

--- a/src/components/shortcuts.jsx
+++ b/src/components/shortcuts.jsx
@@ -1,7 +1,7 @@
 import './shortcuts.css';
 
 import { Trans, useLingui } from '@lingui/react/macro';
-import { ControlledMenu, MenuDivider } from '@szhsin/react-menu';
+import { ControlledMenu, MenuDivider, MenuHeader } from '@szhsin/react-menu';
 import { memo } from 'preact/compat';
 import { useEffect, useRef, useState } from 'preact/hooks';
 import { useHotkeys } from 'react-hotkeys-hook';
@@ -11,7 +11,7 @@ import { useSnapshot } from 'valtio';
 
 import { SHORTCUTS_META } from '../components/shortcuts-settings';
 import { api } from '../utils/api';
-import { getLists } from '../utils/lists';
+import { getLists, splitListsAndFeeds } from '../utils/lists';
 import safeBoundingBoxPadding from '../utils/safe-bounding-box-padding';
 import states from '../utils/states';
 
@@ -25,27 +25,47 @@ import Menu2 from './menu2';
 import SubMenu2 from './submenu2';
 
 function ListsMenuContent({ lists }) {
+  const { lists: userLists, feeds } = splitListsAndFeeds(lists);
   return (
     <>
       <MenuLink to="/l">
         <span>
-          <Trans>All Lists</Trans>
+          <Trans>Lists & Feeds</Trans>
         </span>
       </MenuLink>
       <MenuDivider />
-      {lists?.map((list) => (
-        <MenuLink key={list.id} to={`/l/${list.id}`}>
-          <span>
-            {list.title}
-            {list.exclusive && (
-              <>
-                {' '}
-                <ListExclusiveBadge />
-              </>
-            )}
-          </span>
-        </MenuLink>
-      ))}
+      {userLists.length > 0 && (
+        <>
+          <MenuHeader className="plain">
+            <Trans>Lists</Trans>
+          </MenuHeader>
+          {userLists.map((list) => (
+            <MenuLink key={list.id} to={`/l/${list.id}`}>
+              <span>
+                {list.title}
+                {list.exclusive && (
+                  <>
+                    {' '}
+                    <ListExclusiveBadge />
+                  </>
+                )}
+              </span>
+            </MenuLink>
+          ))}
+        </>
+      )}
+      {feeds.length > 0 && (
+        <>
+          <MenuHeader className="plain">
+            <Trans>Feeds</Trans>
+          </MenuHeader>
+          {feeds.map((feed) => (
+            <MenuLink key={feed.id} to={`/l/${feed.id}`}>
+              <Icon icon="sparkles" /> <span>{feed.title}</span>
+            </MenuLink>
+          ))}
+        </>
+      )}
     </>
   );
 }
@@ -59,9 +79,7 @@ function Shortcuts() {
   if (!shortcuts.length) {
     return null;
   }
-  const isMultiColumnMode =
-    settings.shortcutsViewMode === 'multi-column' ||
-    (!settings.shortcutsViewMode && settings.shortcutsColumnsMode);
+  const isMultiColumnMode = false;
 
   const menuRef = useRef();
   const tabBarRef = useRef();
@@ -296,6 +314,7 @@ function Shortcuts() {
             ref={listsMenuRef}
             state={listsMenuState}
             anchorRef={listsLinkRef}
+            menuClassName="lists-picker-menu"
             onClose={() => {
               setListsMenuState(undefined);
             }}
@@ -350,7 +369,7 @@ function Shortcuts() {
             if (id === 'lists') {
               return (
                 <SubMenu2
-                  menuClassName="glass-menu"
+                  menuClassName="glass-menu lists-picker-menu"
                   overflow="auto"
                   gap={-8}
                   label={

--- a/src/components/status.jsx
+++ b/src/components/status.jsx
@@ -2165,8 +2165,7 @@ function Status({
           size !== 'l' &&
           !previewMode &&
           !readOnly &&
-          !_deleted &&
-          !quoted && (
+          !_deleted && (
             <div
               class={`status-actions ${
                 isContextMenuOpen === 'actions-bar' ? 'open' : ''
@@ -3382,7 +3381,7 @@ const QuoteStatuses = memo(
           <QuoteStatus
             quote={{
               // Same structure as the one in saveStatus (utils/states)
-              id,
+              id: fallbackQuote.quotedStatus.id || fallbackQuote.id || id,
               instance,
               // url
               state: fallbackQuote.state,

--- a/src/locales/en.po
+++ b/src/locales/en.po
@@ -28,12 +28,12 @@ msgid "Last posted: {0}"
 msgstr ""
 
 #: src/components/account-block.jsx:172
-#: src/components/account-info.jsx:738
+#: src/components/account-info.jsx:742
 msgid "Automated"
 msgstr ""
 
 #: src/components/account-block.jsx:179
-#: src/components/account-info.jsx:743
+#: src/components/account-info.jsx:747
 #: src/components/status.jsx:607
 msgid "Group"
 msgstr ""
@@ -62,14 +62,14 @@ msgid "{followersCount, plural, one {# follower} other {# followers}}"
 msgstr ""
 
 #: src/components/account-block.jsx:218
-#: src/components/account-info.jsx:786
+#: src/components/account-info.jsx:790
 msgid "Verified"
 msgstr ""
 
 #. placeholder {0}: niceDateTime(createdAt, { hideTime: true, })
 #. placeholder {0}: niceDateTime(createdAt, { hideTime: true, })
 #: src/components/account-block.jsx:233
-#: src/components/account-info.jsx:925
+#: src/components/account-info.jsx:929
 msgid "Joined <0>{0}</0>"
 msgstr ""
 
@@ -82,8 +82,8 @@ msgid "server domain name"
 msgstr ""
 
 #: src/components/account-info-mini.jsx:57
-#: src/components/account-info.jsx:808
-#: src/components/compose.jsx:2050
+#: src/components/account-info.jsx:812
+#: src/components/compose.jsx:2051
 #: src/pages/settings.jsx:300
 #: src/utils/visibility-text.jsx:7
 msgid "Followers"
@@ -91,34 +91,34 @@ msgstr "Followers"
 
 #: src/components/account-info-mini.jsx:61
 #: src/components/account-info-mini.jsx:100
-#: src/components/account-info.jsx:815
-#: src/components/account-info.jsx:873
+#: src/components/account-info.jsx:819
+#: src/components/account-info.jsx:877
 msgid "This user has chosen to not make this information available."
 msgstr "This user has chosen to not make this information available."
 
 #. placeholder {0}: shortenNumber(followersCount)
 #. placeholder {1}: shortenNumber(followersCount)
 #: src/components/account-info-mini.jsx:67
-#: src/components/account-info.jsx:835
+#: src/components/account-info.jsx:839
 msgid "{followersCount, plural, one {<0>{0}</0> Follower} other {<1>{1}</1> Followers}}"
 msgstr "{followersCount, plural, one {<0>{0}</0> Follower} other {<1>{1}</1> Followers}}"
 
 #. js-lingui-explicit-id
 #: src/components/account-info-mini.jsx:93
-#: src/components/account-info.jsx:863
+#: src/components/account-info.jsx:867
 msgid "following.stats"
 msgstr "Following"
 
 #. placeholder {0}: shortenNumber(followingCount)
 #: src/components/account-info-mini.jsx:106
-#: src/components/account-info.jsx:879
+#: src/components/account-info.jsx:883
 msgid "{followingCount, plural, other {<0>{0}</0> Following}}"
 msgstr "{followingCount, plural, other {<0>{0}</0> Following}}"
 
 #. placeholder {0}: shortenNumber(statusesCount)
 #. placeholder {1}: shortenNumber(statusesCount)
 #: src/components/account-info-mini.jsx:119
-#: src/components/account-info.jsx:903
+#: src/components/account-info.jsx:907
 msgid "{statusesCount, plural, one {<0>{0}</0> Post} other {<1>{1}</1> Posts}}"
 msgstr "{statusesCount, plural, one {<0>{0}</0> Post} other {<1>{1}</1> Posts}}"
 
@@ -137,7 +137,7 @@ msgstr "Go to account page"
 #: src/components/account-info.jsx:417
 #: src/components/timeline.jsx:656
 #: src/components/timeline2.jsx:685
-#: src/pages/home.jsx:243
+#: src/pages/home.jsx:252
 #: src/pages/notifications.jsx:1032
 #: src/pages/status.jsx:1269
 #: src/pages/status.jsx:1745
@@ -148,47 +148,47 @@ msgstr ""
 msgid "<0>{displayName}</0> has indicated that their new account is now:"
 msgstr "<0>{displayName}</0> has indicated that their new account is now:"
 
-#: src/components/account-info.jsx:627
+#: src/components/account-info.jsx:631
 #: src/components/related-actions.jsx:530
 msgid "Handle copied"
 msgstr "Handle copied"
 
-#: src/components/account-info.jsx:630
+#: src/components/account-info.jsx:634
 #: src/components/related-actions.jsx:533
 msgid "Unable to copy handle"
 msgstr "Unable to copy handle"
 
-#: src/components/account-info.jsx:636
+#: src/components/account-info.jsx:640
 #: src/components/related-actions.jsx:539
 msgid "Copy handle"
 msgstr ""
 
-#: src/components/account-info.jsx:654
+#: src/components/account-info.jsx:658
 #: src/components/related-actions.jsx:255
 #: src/components/related-actions.jsx:604
-#: src/components/shortcuts-settings.jsx:1099
+#: src/components/shortcuts-settings.jsx:1091
 msgid "QR code"
 msgstr "QR code"
 
-#: src/components/account-info.jsx:660
+#: src/components/account-info.jsx:664
 msgid "Go to original profile page"
 msgstr ""
 
-#: src/components/account-info.jsx:679
+#: src/components/account-info.jsx:683
 msgid "View profile image"
 msgstr "View profile image"
 
-#: src/components/account-info.jsx:698
+#: src/components/account-info.jsx:702
 msgid "View profile header"
 msgstr "View profile header"
 
-#: src/components/account-info.jsx:714
+#: src/components/account-info.jsx:718
 #: src/components/edit-profile-sheet.jsx:94
 #: src/components/related-actions.jsx:856
 msgid "Edit profile"
 msgstr ""
 
-#: src/components/account-info.jsx:733
+#: src/components/account-info.jsx:737
 msgid "In Memoriam"
 msgstr ""
 
@@ -196,14 +196,14 @@ msgstr ""
 #. placeholder {1}: ( postingStats.replies / postingStats.total ).toLocaleString(i18n.locale || undefined, { style: 'percent', })
 #. placeholder {2}: ( postingStats.quotes / postingStats.total ).toLocaleString(i18n.locale || undefined, { style: 'percent', })
 #. placeholder {3}: ( postingStats.boosts / postingStats.total ).toLocaleString(i18n.locale || undefined, { style: 'percent', })
-#: src/components/account-info.jsx:960
+#: src/components/account-info.jsx:964
 msgid "{0} original posts, {1} replies, {2} quotes, {3} boosts"
 msgstr "{0} original posts, {1} replies, {2} quotes, {3} boosts"
 
 #. placeholder {0}: ( postingStats.originals / postingStats.total ).toLocaleString(i18n.locale || undefined, { style: 'percent', })
 #. placeholder {1}: ( postingStats.replies / postingStats.total ).toLocaleString(i18n.locale || undefined, { style: 'percent', })
 #. placeholder {2}: ( postingStats.boosts / postingStats.total ).toLocaleString(i18n.locale || undefined, { style: 'percent', })
-#: src/components/account-info.jsx:977
+#: src/components/account-info.jsx:981
 msgid "{0} original posts, {1} replies, {2} boosts"
 msgstr "{0} original posts, {1} replies, {2} boosts"
 
@@ -214,24 +214,24 @@ msgstr "{0} original posts, {1} replies, {2} boosts"
 #. placeholder {4}: postingStats.total
 #. placeholder {5}: postingStats.total
 #. placeholder {6}: postingStats.daysSinceLastPost
-#: src/components/account-info.jsx:994
+#: src/components/account-info.jsx:998
 msgid "{0, plural, one {{1, plural, one {Last 1 post in the past 1 day} other {Last 1 post in the past {2} days}}} other {{3, plural, one {Last {4} posts in the past 1 day} other {Last {5} posts in the past {6} days}}}}"
 msgstr "{0, plural, one {{1, plural, one {Last 1 post in the past 1 day} other {Last 1 post in the past {2} days}}} other {{3, plural, one {Last {4} posts in the past 1 day} other {Last {5} posts in the past {6} days}}}}"
 
 #. placeholder {0}: postingStats.total
 #. placeholder {1}: postingStats.total
-#: src/components/account-info.jsx:1010
+#: src/components/account-info.jsx:1014
 msgid "{0, plural, one {Last 1 post in the past year(s)} other {Last {1} posts in the past year(s)}}"
 msgstr "{0, plural, one {Last 1 post in the past year(s)} other {Last {1} posts in the past year(s)}}"
 
-#: src/components/account-info.jsx:1068
+#: src/components/account-info.jsx:1072
 #: src/pages/catchup.jsx:73
 #: src/pages/year-in-posts.jsx:1390
 msgid "Original"
 msgstr ""
 
-#: src/components/account-info.jsx:1072
-#: src/components/status.jsx:2785
+#: src/components/account-info.jsx:1076
+#: src/components/status.jsx:2784
 #: src/pages/account-statuses.jsx:428
 #: src/pages/catchup.jsx:74
 #: src/pages/catchup.jsx:1594
@@ -242,16 +242,16 @@ msgstr ""
 msgid "Replies"
 msgstr ""
 
-#: src/components/account-info.jsx:1077
+#: src/components/account-info.jsx:1081
 #: src/components/quotes-modal.jsx:81
-#: src/components/status.jsx:2790
+#: src/components/status.jsx:2789
 #: src/pages/catchup.jsx:75
 #: src/pages/catchup.jsx:1597
 #: src/pages/year-in-posts.jsx:1400
 msgid "Quotes"
 msgstr "Quotes"
 
-#: src/components/account-info.jsx:1082
+#: src/components/account-info.jsx:1086
 #: src/pages/account-statuses.jsx:444
 #: src/pages/catchup.jsx:76
 #: src/pages/catchup.jsx:1596
@@ -261,17 +261,17 @@ msgstr "Quotes"
 msgid "Boosts"
 msgstr ""
 
-#: src/components/account-info.jsx:1088
+#: src/components/account-info.jsx:1092
 msgid "Post stats unavailable."
 msgstr "Post stats unavailable."
 
-#: src/components/account-info.jsx:1115
+#: src/components/account-info.jsx:1119
 msgid "View post stats"
 msgstr "View post stats"
 
 #: src/components/account-sheet.jsx:38
 #: src/components/add-remove-lists-sheet.jsx:45
-#: src/components/compose.jsx:1127
+#: src/components/compose.jsx:1128
 #: src/components/custom-emojis-modal.jsx:281
 #: src/components/drafts.jsx:57
 #: src/components/edit-profile-sheet.jsx:89
@@ -296,16 +296,16 @@ msgstr "View post stats"
 #: src/components/quote-settings-sheet.jsx:61
 #: src/components/quotes-modal.jsx:76
 #: src/components/report-modal.jsx:118
-#: src/components/shortcuts-settings.jsx:247
-#: src/components/shortcuts-settings.jsx:600
-#: src/components/shortcuts-settings.jsx:801
-#: src/components/status.jsx:3455
-#: src/components/status.jsx:3667
+#: src/components/shortcuts-settings.jsx:244
+#: src/components/shortcuts-settings.jsx:581
+#: src/components/shortcuts-settings.jsx:793
+#: src/components/status.jsx:3454
+#: src/components/status.jsx:3666
 #: src/components/translated-bio-sheet.jsx:21
 #: src/pages/accounts.jsx:46
 #: src/pages/catchup.jsx:1731
 #: src/pages/filters.jsx:225
-#: src/pages/list.jsx:302
+#: src/pages/list.jsx:345
 #: src/pages/notifications.jsx:1076
 #: src/pages/scheduled-posts.jsx:288
 #: src/pages/settings.jsx:104
@@ -328,7 +328,7 @@ msgid "Unable to add to list."
 msgstr "Unable to add to list."
 
 #: src/components/add-remove-lists-sheet.jsx:110
-#: src/pages/lists.jsx:131
+#: src/pages/lists.jsx:165
 msgid "Unable to load lists."
 msgstr ""
 
@@ -338,7 +338,7 @@ msgstr ""
 
 #: src/components/add-remove-lists-sheet.jsx:125
 #: src/components/list-add-edit.jsx:41
-#: src/pages/lists.jsx:62
+#: src/pages/lists.jsx:63
 msgid "New list"
 msgstr ""
 
@@ -356,15 +356,15 @@ msgid "More from <0/>"
 msgstr "More from <0/>"
 
 #: src/components/columns.jsx:29
-#: src/components/nav-menu.jsx:187
-#: src/components/shortcuts-settings.jsx:142
+#: src/components/nav-menu.jsx:184
+#: src/components/shortcuts-settings.jsx:141
 #: src/components/timeline.jsx:539
 #: src/components/timeline2.jsx:564
 #: src/pages/catchup.jsx:1027
 #: src/pages/filters.jsx:90
 #: src/pages/followed-hashtags.jsx:41
-#: src/pages/home.jsx:61
-#: src/pages/home.jsx:69
+#: src/pages/home.jsx:63
+#: src/pages/home.jsx:78
 #: src/pages/notifications.jsx:709
 #: src/pages/scheduled-posts.jsx:74
 msgid "Home"
@@ -376,7 +376,7 @@ msgid "Compose"
 msgstr ""
 
 #: src/components/compose-button.jsx:181
-#: src/components/nav-menu.jsx:271
+#: src/components/nav-menu.jsx:268
 #: src/pages/scheduled-posts.jsx:31
 #: src/pages/scheduled-posts.jsx:78
 msgid "Scheduled Posts"
@@ -393,17 +393,17 @@ msgstr "Choice {0}"
 
 #: src/components/compose-poll.jsx:64
 #: src/components/media-attachment.jsx:379
-#: src/components/shortcuts-settings.jsx:743
+#: src/components/shortcuts-settings.jsx:735
 #: src/pages/catchup.jsx:1228
 #: src/pages/filters.jsx:415
 msgid "Remove"
 msgstr ""
 
 #: src/components/compose-poll.jsx:80
-#: src/components/compose.jsx:1758
+#: src/components/compose.jsx:1759
 #: src/components/mention-modal.jsx:221
-#: src/components/shortcuts-settings.jsx:732
-#: src/pages/list.jsx:388
+#: src/components/shortcuts-settings.jsx:724
+#: src/pages/list.jsx:431
 msgid "Add"
 msgstr ""
 
@@ -455,7 +455,7 @@ msgid "{0, plural, one {File {1} is not supported.} other {Files {2} are not sup
 msgstr "{0, plural, one {File {1} is not supported.} other {Files {2} are not supported.}}"
 
 #: src/components/compose.jsx:293
-#: src/components/compose.jsx:2184
+#: src/components/compose.jsx:2185
 #: src/components/file-picker-input.jsx:47
 msgid "{maxMediaAttachments, plural, one {You can only attach up to 1 file.} other {You can only attach up to # files.}}"
 msgstr ""
@@ -464,69 +464,69 @@ msgstr ""
 msgid "You have unsaved changes. Discard this post?"
 msgstr "You have unsaved changes. Discard this post?"
 
-#: src/components/compose.jsx:1107
+#: src/components/compose.jsx:1108
 msgid "Pop out"
 msgstr "Pop out"
 
-#: src/components/compose.jsx:1115
+#: src/components/compose.jsx:1116
 msgid "Minimize"
 msgstr "Minimize"
 
-#: src/components/compose.jsx:1151
+#: src/components/compose.jsx:1152
 msgid "Looks like you closed the parent window."
 msgstr "Looks like you closed the parent window."
 
-#: src/components/compose.jsx:1158
+#: src/components/compose.jsx:1159
 msgid "Looks like you already have a compose field open in the parent window and currently publishing. Please wait for it to be done and try again later."
 msgstr "Looks like you already have a compose field open in the parent window and currently publishing. Please wait for it to be done and try again later."
 
-#: src/components/compose.jsx:1163
+#: src/components/compose.jsx:1164
 msgid "Looks like you already have a compose field open in the parent window. Popping in this window will discard the changes you made in the parent window. Continue?"
 msgstr "Looks like you already have a compose field open in the parent window. Popping in this window will discard the changes you made in the parent window. Continue?"
 
-#: src/components/compose.jsx:1209
+#: src/components/compose.jsx:1210
 msgid "Pop in"
 msgstr "Pop in"
 
 #. placeholder {0}: replyToStatus.account.acct || replyToStatus.account.username
 #. placeholder {1}: rtf.format(-replyToStatusMonthsAgo, 'month')
-#: src/components/compose.jsx:1219
+#: src/components/compose.jsx:1220
 msgid "Replying to @{0}’s post (<0>{1}</0>)"
 msgstr ""
 
 #. placeholder {0}: replyToStatus.account.acct || replyToStatus.account.username
-#: src/components/compose.jsx:1229
+#: src/components/compose.jsx:1230
 msgid "Replying to @{0}’s post"
 msgstr ""
 
-#: src/components/compose.jsx:1242
+#: src/components/compose.jsx:1243
 msgid "Editing source post"
 msgstr ""
 
-#: src/components/compose.jsx:1311
+#: src/components/compose.jsx:1312
 msgid "Poll must have at least 2 options"
 msgstr "Poll must have at least 2 options"
 
-#: src/components/compose.jsx:1315
+#: src/components/compose.jsx:1316
 msgid "Some poll choices are empty"
 msgstr "Some poll choices are empty"
 
-#: src/components/compose.jsx:1328
+#: src/components/compose.jsx:1329
 msgid "Some media have no descriptions. Continue?"
 msgstr "Some media have no descriptions. Continue?"
 
-#: src/components/compose.jsx:1385
+#: src/components/compose.jsx:1386
 msgid "Attachment #{i} failed"
 msgstr "Attachment #{i} failed"
 
-#: src/components/compose.jsx:1514
-#: src/components/status.jsx:2547
+#: src/components/compose.jsx:1515
+#: src/components/status.jsx:2546
 #: src/components/timeline.jsx:1065
 msgid "Content warning"
 msgstr ""
 
-#: src/components/compose.jsx:1546
-#: src/components/compose.jsx:1692
+#: src/components/compose.jsx:1547
+#: src/components/compose.jsx:1693
 #: src/components/edit-profile-sheet.jsx:326
 #: src/components/import-accounts-selection.jsx:175
 #: src/components/open-link-sheet.jsx:74
@@ -535,109 +535,109 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/components/compose.jsx:1554
+#: src/components/compose.jsx:1555
 msgid "Post your reply"
 msgstr "Post your reply"
 
-#: src/components/compose.jsx:1556
+#: src/components/compose.jsx:1557
 msgid "Edit your post"
 msgstr "Edit your post"
 
-#: src/components/compose.jsx:1558
+#: src/components/compose.jsx:1559
 msgid "Ask a question"
 msgstr "Ask a question"
 
-#: src/components/compose.jsx:1559
+#: src/components/compose.jsx:1560
 msgid "What are you doing?"
 msgstr "What are you doing?"
 
-#: src/components/compose.jsx:1632
+#: src/components/compose.jsx:1633
 msgid "Mark media as sensitive"
 msgstr ""
 
-#: src/components/compose.jsx:1672
+#: src/components/compose.jsx:1673
 msgid "Posting on <0/>"
 msgstr "Posting on <0/>"
 
-#: src/components/compose.jsx:1970
+#: src/components/compose.jsx:1971
 #: src/components/quote-settings-sheet.jsx:82
 #: src/components/status.jsx:298
 #: src/pages/settings.jsx:342
 msgid "Anyone can quote"
 msgstr "Anyone can quote"
 
-#: src/components/compose.jsx:1973
+#: src/components/compose.jsx:1974
 #: src/components/quote-settings-sheet.jsx:85
 #: src/components/status.jsx:299
 #: src/pages/settings.jsx:345
 msgid "Your followers can quote"
 msgstr "Your followers can quote"
 
-#: src/components/compose.jsx:1976
+#: src/components/compose.jsx:1977
 #: src/components/quote-settings-sheet.jsx:88
 #: src/components/status.jsx:300
 #: src/pages/settings.jsx:348
 msgid "Only you can quote"
 msgstr "Only you can quote"
 
-#: src/components/compose.jsx:2016
+#: src/components/compose.jsx:2017
 msgid "Quotes can't be embedded in private mentions."
 msgstr "Quotes can't be embedded in private mentions."
 
-#: src/components/compose.jsx:2038
+#: src/components/compose.jsx:2039
 #: src/pages/settings.jsx:294
 #: src/utils/visibility-text.jsx:4
 msgid "Public"
 msgstr ""
 
-#: src/components/compose.jsx:2043
-#: src/components/nav-menu.jsx:355
-#: src/components/shortcuts-settings.jsx:168
+#: src/components/compose.jsx:2044
+#: src/components/nav-menu.jsx:352
+#: src/components/shortcuts-settings.jsx:166
 #: src/utils/visibility-text.jsx:5
 msgid "Local"
 msgstr ""
 
-#: src/components/compose.jsx:2047
+#: src/components/compose.jsx:2048
 #: src/pages/settings.jsx:297
 #: src/utils/visibility-text.jsx:6
 msgid "Quiet public"
 msgstr "Quiet public"
 
-#: src/components/compose.jsx:2053
-#: src/components/status.jsx:2426
+#: src/components/compose.jsx:2054
+#: src/components/status.jsx:2425
 #: src/utils/visibility-text.jsx:8
 msgid "Private mention"
 msgstr ""
 
-#: src/components/compose.jsx:2109
+#: src/components/compose.jsx:2110
 msgid "Schedule"
 msgstr "Schedule"
 
-#: src/components/compose.jsx:2111
-#: src/components/keyboard-shortcuts-help.jsx:165
+#: src/components/compose.jsx:2112
+#: src/components/keyboard-shortcuts-help.jsx:149
 #: src/components/status.jsx:1103
 #: src/components/status.jsx:1152
+#: src/components/status.jsx:2177
 #: src/components/status.jsx:2178
-#: src/components/status.jsx:2179
-#: src/components/status.jsx:2917
-#: src/components/status.jsx:2929
+#: src/components/status.jsx:2916
+#: src/components/status.jsx:2928
 msgid "Reply"
 msgstr ""
 
-#: src/components/compose.jsx:2113
+#: src/components/compose.jsx:2114
 msgid "Update"
 msgstr "Update"
 
-#: src/components/compose.jsx:2114
+#: src/components/compose.jsx:2115
 msgctxt "Submit button in composer"
 msgid "Post"
 msgstr "Post"
 
-#: src/components/compose.jsx:2196
+#: src/components/compose.jsx:2197
 msgid "Downloading GIF…"
 msgstr "Downloading GIF…"
 
-#: src/components/compose.jsx:2220
+#: src/components/compose.jsx:2221
 msgid "Failed to download GIF"
 msgstr "Failed to download GIF"
 
@@ -738,7 +738,7 @@ msgid "Media"
 msgstr ""
 
 #: src/components/drafts.jsx:283
-#: src/components/keyboard-shortcuts-help.jsx:194
+#: src/components/keyboard-shortcuts-help.jsx:178
 #: src/components/status.jsx:764
 msgid "Quote"
 msgstr ""
@@ -801,7 +801,7 @@ msgstr ""
 #: src/components/edit-profile-sheet.jsx:329
 #: src/components/list-add-edit.jsx:152
 #: src/components/quote-settings-sheet.jsx:92
-#: src/components/shortcuts-settings.jsx:732
+#: src/components/shortcuts-settings.jsx:724
 #: src/pages/filters.jsx:572
 #: src/pages/notifications.jsx:1142
 msgid "Save"
@@ -849,7 +849,7 @@ msgstr ""
 #: src/components/generic-accounts.jsx:214
 #: src/components/quotes-modal.jsx:129
 #: src/components/timeline.jsx:621
-#: src/pages/list.jsx:321
+#: src/pages/list.jsx:364
 #: src/pages/notifications.jsx:1056
 #: src/pages/search.jsx:576
 #: src/pages/status.jsx:1716
@@ -919,7 +919,7 @@ msgid "Import/Export <0>Accounts</0>"
 msgstr "Import/Export <0>Accounts</0>"
 
 #: src/components/import-export-accounts.jsx:128
-#: src/components/shortcuts-settings.jsx:816
+#: src/components/shortcuts-settings.jsx:808
 msgid "Import"
 msgstr ""
 
@@ -928,7 +928,7 @@ msgid "Select file…"
 msgstr "Select file…"
 
 #: src/components/import-export-accounts.jsx:151
-#: src/components/shortcuts-settings.jsx:1066
+#: src/components/shortcuts-settings.jsx:1058
 msgid "Export"
 msgstr ""
 
@@ -946,7 +946,7 @@ msgid "<0>{key1}</0> then <1>{key2}</1>"
 msgstr "<0>{key1}</0> then <1>{key2}</1>"
 
 #: src/components/keyboard-shortcuts-help.jsx:57
-#: src/components/nav-menu.jsx:374
+#: src/components/nav-menu.jsx:371
 #: src/pages/catchup.jsx:1769
 msgid "Keyboard shortcuts"
 msgstr ""
@@ -1007,110 +1007,94 @@ msgid "<0>Esc</0> or <1>Backspace</1>"
 msgstr ""
 
 #: src/components/keyboard-shortcuts-help.jsx:123
-msgid "Focus column in multi-column mode"
-msgstr ""
-
-#: src/components/keyboard-shortcuts-help.jsx:125
-msgid "<0>1</0> to <1>9</1>"
-msgstr ""
-
-#: src/components/keyboard-shortcuts-help.jsx:131
-msgid "Focus next column in multi-column mode"
-msgstr "Focus next column in multi-column mode"
-
-#: src/components/keyboard-shortcuts-help.jsx:135
-msgid "Focus previous column in multi-column mode"
-msgstr "Focus previous column in multi-column mode"
-
-#: src/components/keyboard-shortcuts-help.jsx:139
 msgid "Compose new post"
 msgstr ""
 
-#: src/components/keyboard-shortcuts-help.jsx:143
+#: src/components/keyboard-shortcuts-help.jsx:127
 msgid "Compose new post (new window)"
 msgstr ""
 
-#: src/components/keyboard-shortcuts-help.jsx:146
+#: src/components/keyboard-shortcuts-help.jsx:130
 msgid "<0>Shift</0> + <1>c</1>"
 msgstr ""
 
-#: src/components/keyboard-shortcuts-help.jsx:152
+#: src/components/keyboard-shortcuts-help.jsx:136
 msgid "Send post"
 msgstr ""
 
-#: src/components/keyboard-shortcuts-help.jsx:154
+#: src/components/keyboard-shortcuts-help.jsx:138
 msgid "<0>Ctrl</0> + <1>Enter</1> or <2>⌘</2> + <3>Enter</3>"
 msgstr ""
 
-#: src/components/keyboard-shortcuts-help.jsx:161
-#: src/components/nav-menu.jsx:343
+#: src/components/keyboard-shortcuts-help.jsx:145
+#: src/components/nav-menu.jsx:340
 #: src/components/search-form.jsx:208
-#: src/components/shortcuts-settings.jsx:54
-#: src/components/shortcuts-settings.jsx:182
+#: src/components/shortcuts-settings.jsx:53
+#: src/components/shortcuts-settings.jsx:180
 #: src/pages/search.jsx:47
 #: src/pages/search.jsx:331
 msgid "Search"
 msgstr ""
 
-#: src/components/keyboard-shortcuts-help.jsx:169
+#: src/components/keyboard-shortcuts-help.jsx:153
 msgid "Reply (new window)"
 msgstr ""
 
-#: src/components/keyboard-shortcuts-help.jsx:172
+#: src/components/keyboard-shortcuts-help.jsx:156
 msgid "<0>Shift</0> + <1>r</1>"
 msgstr ""
 
-#: src/components/keyboard-shortcuts-help.jsx:178
+#: src/components/keyboard-shortcuts-help.jsx:162
 msgid "Like (favourite)"
 msgstr ""
 
-#: src/components/keyboard-shortcuts-help.jsx:180
+#: src/components/keyboard-shortcuts-help.jsx:164
 msgid "<0>l</0> or <1>f</1>"
 msgstr ""
 
-#: src/components/keyboard-shortcuts-help.jsx:186
+#: src/components/keyboard-shortcuts-help.jsx:170
 #: src/components/status.jsx:1195
-#: src/components/status.jsx:2966
-#: src/components/status.jsx:3032
+#: src/components/status.jsx:2965
+#: src/components/status.jsx:3031
 msgid "Boost"
 msgstr ""
 
-#: src/components/keyboard-shortcuts-help.jsx:188
+#: src/components/keyboard-shortcuts-help.jsx:172
 msgid "<0>Shift</0> + <1>b</1>"
 msgstr ""
 
-#: src/components/keyboard-shortcuts-help.jsx:198
+#: src/components/keyboard-shortcuts-help.jsx:182
 #: src/components/status.jsx:1298
+#: src/components/status.jsx:3063
 #: src/components/status.jsx:3064
-#: src/components/status.jsx:3065
 msgid "Bookmark"
 msgstr ""
 
-#: src/components/keyboard-shortcuts-help.jsx:202
+#: src/components/keyboard-shortcuts-help.jsx:186
 msgid "Toggle Cloak mode"
 msgstr ""
 
-#: src/components/keyboard-shortcuts-help.jsx:204
+#: src/components/keyboard-shortcuts-help.jsx:188
 msgid "<0>Shift</0> + <1>Alt</1> + <2>k</2>"
 msgstr ""
 
-#: src/components/keyboard-shortcuts-help.jsx:210
+#: src/components/keyboard-shortcuts-help.jsx:194
 msgid "Go to Home"
 msgstr "Go to Home"
 
-#: src/components/keyboard-shortcuts-help.jsx:214
+#: src/components/keyboard-shortcuts-help.jsx:198
 msgid "Go to Notifications"
 msgstr "Go to Notifications"
 
-#: src/components/keyboard-shortcuts-help.jsx:218
+#: src/components/keyboard-shortcuts-help.jsx:202
 msgid "Go to Settings"
 msgstr "Go to Settings"
 
-#: src/components/keyboard-shortcuts-help.jsx:222
+#: src/components/keyboard-shortcuts-help.jsx:206
 msgid "Go to Profile"
 msgstr "Go to Profile"
 
-#: src/components/keyboard-shortcuts-help.jsx:226
+#: src/components/keyboard-shortcuts-help.jsx:210
 msgid "Go to Bookmarks"
 msgstr "Go to Bookmarks"
 
@@ -1156,8 +1140,8 @@ msgid "Unable to delete list."
 msgstr ""
 
 #: src/components/list-exclusive-badge.jsx:14
-#: src/pages/list.jsx:179
-#: src/pages/lists.jsx:107
+#: src/pages/list.jsx:220
+#: src/pages/lists.jsx:131
 msgid "Posts on this list are hidden from Home/Following"
 msgstr "Posts on this list are hidden from Home/Following"
 
@@ -1188,15 +1172,15 @@ msgstr ""
 #: src/components/media-attachment.jsx:460
 #: src/components/media-modal.jsx:372
 #: src/components/related-actions.jsx:273
-#: src/components/status.jsx:2203
-#: src/components/status.jsx:2220
-#: src/components/status.jsx:2352
-#: src/components/status.jsx:3088
-#: src/components/status.jsx:3091
+#: src/components/status.jsx:2202
+#: src/components/status.jsx:2219
+#: src/components/status.jsx:2351
+#: src/components/status.jsx:3087
+#: src/components/status.jsx:3090
 #: src/pages/account-statuses.jsx:676
 #: src/pages/accounts.jsx:149
 #: src/pages/hashtag.jsx:232
-#: src/pages/list.jsx:171
+#: src/pages/list.jsx:212
 #: src/pages/public.jsx:147
 #: src/pages/scheduled-posts.jsx:89
 #: src/pages/status.jsx:1584
@@ -1341,8 +1325,8 @@ msgstr ""
 
 #: src/components/media-post.jsx:133
 #: src/components/status-compact.jsx:74
-#: src/components/status.jsx:3593
-#: src/components/status.jsx:3671
+#: src/components/status.jsx:3592
+#: src/components/status.jsx:3670
 #: src/components/timeline.jsx:1054
 #: src/pages/catchup.jsx:79
 #: src/pages/catchup.jsx:2052
@@ -1377,38 +1361,38 @@ msgstr ""
 msgid "Post updated. Check it out."
 msgstr ""
 
-#: src/components/nav-menu.jsx:129
+#: src/components/nav-menu.jsx:126
 msgid "Menu"
 msgstr ""
 
-#: src/components/nav-menu.jsx:165
+#: src/components/nav-menu.jsx:162
 msgid "Reload page now to update?"
 msgstr ""
 
-#: src/components/nav-menu.jsx:177
+#: src/components/nav-menu.jsx:174
 msgid "New update available…"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/components/nav-menu.jsx:196
-#: src/components/shortcuts-settings.jsx:143
-#: src/pages/following.jsx:23
-#: src/pages/following.jsx:156
-#: src/pages/following2.jsx:18
-#: src/pages/following2.jsx:133
+#: src/components/nav-menu.jsx:193
+#: src/components/shortcuts-settings.jsx:142
+#: src/pages/following.jsx:24
+#: src/pages/following.jsx:164
+#: src/pages/following2.jsx:19
+#: src/pages/following2.jsx:141
 msgid "following.title"
 msgstr "Following"
 
-#: src/components/nav-menu.jsx:203
+#: src/components/nav-menu.jsx:200
 #: src/pages/catchup.jsx:1022
-#: src/pages/welcome.jsx:154
+#: src/pages/welcome.jsx:153
 msgid "Catch-up"
 msgstr ""
 
-#: src/components/nav-menu.jsx:210
-#: src/components/shortcuts-settings.jsx:60
-#: src/components/shortcuts-settings.jsx:149
-#: src/pages/home.jsx:255
+#: src/components/nav-menu.jsx:207
+#: src/components/shortcuts-settings.jsx:59
+#: src/components/shortcuts-settings.jsx:148
+#: src/pages/home.jsx:264
 #: src/pages/mentions.jsx:25
 #: src/pages/mentions.jsx:256
 #: src/pages/notifications.jsx:933
@@ -1417,43 +1401,44 @@ msgstr ""
 msgid "Mentions"
 msgstr ""
 
-#: src/components/nav-menu.jsx:217
-#: src/components/shortcuts-settings.jsx:51
-#: src/components/shortcuts-settings.jsx:155
+#: src/components/nav-menu.jsx:214
+#: src/components/shortcuts-settings.jsx:50
+#: src/components/shortcuts-settings.jsx:154
 #: src/pages/filters.jsx:24
-#: src/pages/home.jsx:101
-#: src/pages/home.jsx:213
+#: src/pages/home.jsx:110
+#: src/pages/home.jsx:222
+#: src/pages/list.jsx:201
 #: src/pages/notifications.jsx:112
 #: src/pages/notifications.jsx:713
 msgid "Notifications"
 msgstr ""
 
-#: src/components/nav-menu.jsx:220
+#: src/components/nav-menu.jsx:217
 msgid "New"
 msgstr ""
 
-#: src/components/nav-menu.jsx:231
-#: src/components/shortcuts-settings.jsx:61
-#: src/components/shortcuts-settings.jsx:192
+#: src/components/nav-menu.jsx:228
+#: src/components/shortcuts-settings.jsx:60
+#: src/components/shortcuts-settings.jsx:189
 msgid "Profile"
 msgstr ""
 
-#: src/components/nav-menu.jsx:239
-#: src/components/shortcuts-settings.jsx:56
-#: src/components/shortcuts-settings.jsx:212
+#: src/components/nav-menu.jsx:236
+#: src/components/shortcuts-settings.jsx:55
+#: src/components/shortcuts-settings.jsx:209
 #: src/pages/bookmarks.jsx:12
 #: src/pages/bookmarks.jsx:26
 msgid "Bookmarks"
 msgstr ""
 
-#: src/components/nav-menu.jsx:250
+#: src/components/nav-menu.jsx:247
 #: src/components/text-expander.jsx:215
 msgid "More…"
 msgstr ""
 
-#: src/components/nav-menu.jsx:259
-#: src/components/shortcuts-settings.jsx:57
-#: src/components/shortcuts-settings.jsx:218
+#: src/components/nav-menu.jsx:256
+#: src/components/shortcuts-settings.jsx:56
+#: src/components/shortcuts-settings.jsx:215
 #: src/pages/catchup.jsx:1595
 #: src/pages/catchup.jsx:2255
 #: src/pages/favourites.jsx:12
@@ -1462,13 +1447,13 @@ msgstr ""
 msgid "Likes"
 msgstr ""
 
-#: src/components/nav-menu.jsx:265
+#: src/components/nav-menu.jsx:262
 #: src/pages/followed-hashtags.jsx:15
 #: src/pages/followed-hashtags.jsx:45
 msgid "Followed Hashtags"
 msgstr ""
 
-#: src/components/nav-menu.jsx:279
+#: src/components/nav-menu.jsx:276
 #: src/pages/account-statuses.jsx:410
 #: src/pages/filters.jsx:55
 #: src/pages/filters.jsx:94
@@ -1476,70 +1461,83 @@ msgstr ""
 msgid "Filters"
 msgstr ""
 
-#: src/components/nav-menu.jsx:287
+#: src/components/nav-menu.jsx:284
 msgid "Muted users"
 msgstr ""
 
-#: src/components/nav-menu.jsx:295
+#: src/components/nav-menu.jsx:292
 msgid "Muted users…"
 msgstr ""
 
-#: src/components/nav-menu.jsx:302
+#: src/components/nav-menu.jsx:299
 msgid "Blocked users"
 msgstr ""
 
-#: src/components/nav-menu.jsx:310
+#: src/components/nav-menu.jsx:307
 msgid "Blocked users…"
 msgstr ""
 
-#: src/components/nav-menu.jsx:322
+#: src/components/nav-menu.jsx:319
 msgid "Accounts…"
 msgstr ""
 
-#: src/components/nav-menu.jsx:332
-#: src/pages/login.jsx:33
-#: src/pages/login.jsx:227
+#: src/components/nav-menu.jsx:329
+#: src/pages/login.jsx:41
+#: src/pages/login.jsx:276
 #: src/pages/status.jsx:1109
-#: src/pages/welcome.jsx:63
+#: src/pages/welcome.jsx:62
 msgid "Log in"
 msgstr ""
 
-#: src/components/nav-menu.jsx:349
-#: src/components/shortcuts-settings.jsx:59
-#: src/components/shortcuts-settings.jsx:175
+#: src/components/nav-menu.jsx:346
+#: src/components/shortcuts-settings.jsx:58
+#: src/components/shortcuts-settings.jsx:173
 #: src/pages/trending.jsx:444
 msgid "Trending"
 msgstr ""
 
-#: src/components/nav-menu.jsx:361
-#: src/components/shortcuts-settings.jsx:168
+#: src/components/nav-menu.jsx:358
+#: src/components/shortcuts-settings.jsx:166
 msgid "Federated"
 msgstr ""
 
-#: src/components/nav-menu.jsx:384
-msgid "Shortcuts / Columns…"
-msgstr ""
+#: src/components/nav-menu.jsx:381
+msgid "Shortcuts…"
+msgstr "Shortcuts…"
 
-#: src/components/nav-menu.jsx:394
-#: src/components/nav-menu.jsx:408
+#: src/components/nav-menu.jsx:391
+#: src/components/nav-menu.jsx:405
 msgid "Settings…"
 msgstr ""
 
-#: src/components/nav-menu.jsx:438
-#: src/components/nav-menu.jsx:473
-#: src/components/shortcuts-settings.jsx:52
-#: src/components/shortcuts-settings.jsx:161
-#: src/pages/list.jsx:127
+#: src/components/nav-menu.jsx:436
+#: src/components/nav-menu.jsx:444
+#: src/components/nav-menu.jsx:490
+#: src/components/shortcuts-settings.jsx:51
+#: src/components/shortcuts-settings.jsx:160
+#: src/components/shortcuts.jsx:33
+#: src/pages/list.jsx:146
+#: src/pages/list.jsx:158
 #: src/pages/lists.jsx:18
-#: src/pages/lists.jsx:54
+#: src/pages/lists.jsx:55
+msgid "Lists & Feeds"
+msgstr "Lists & Feeds"
+
+#: src/components/nav-menu.jsx:453
+#: src/components/shortcuts-settings.jsx:658
+#: src/components/shortcuts.jsx:40
+#: src/pages/list.jsx:165
+#: src/pages/lists.jsx:74
 msgid "Lists"
 msgstr ""
 
-#: src/components/nav-menu.jsx:446
-#: src/components/shortcuts.jsx:32
-#: src/pages/list.jsx:139
-msgid "All Lists"
-msgstr ""
+#: src/components/nav-menu.jsx:473
+#: src/components/shortcuts-settings.jsx:665
+#: src/components/shortcuts.jsx:60
+#: src/pages/list.jsx:186
+#: src/pages/lists.jsx:112
+msgid "Feeds"
+msgstr "Feeds"
 
 #: src/components/notification-service.jsx:161
 msgid "Notification"
@@ -1729,7 +1727,7 @@ msgstr "Open link?"
 #: src/components/open-link-sheet.jsx:78
 #: src/components/post-embed-modal.jsx:232
 #: src/components/related-actions.jsx:565
-#: src/components/shortcuts-settings.jsx:1175
+#: src/components/shortcuts-settings.jsx:1167
 #: src/components/status.jsx:1495
 msgid "Copy"
 msgstr ""
@@ -1894,7 +1892,7 @@ msgid "Save & close"
 msgstr ""
 
 #: src/components/qr-code-modal.jsx:26
-#: src/components/shortcuts-settings.jsx:849
+#: src/components/shortcuts-settings.jsx:841
 msgid "Scan QR code"
 msgstr "Scan QR code"
 
@@ -2074,7 +2072,7 @@ msgid "Search my posts"
 msgstr "Search my posts"
 
 #: src/components/related-actions.jsx:580
-#: src/components/shortcuts-settings.jsx:1193
+#: src/components/shortcuts-settings.jsx:1185
 #: src/components/status.jsx:1511
 msgid "Sharing doesn't seem to work."
 msgstr ""
@@ -2314,293 +2312,272 @@ msgid "Look up <0>{query}</0>"
 msgstr ""
 
 #: src/components/search-form.jsx:366
-#: src/pages/home.jsx:266
+#: src/pages/home.jsx:275
 msgid "See all"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:50
+#: src/components/shortcuts-settings.jsx:49
 msgid "Home / Following"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:53
+#: src/components/shortcuts-settings.jsx:52
 msgid "Public (Local / Federated)"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:55
+#: src/components/shortcuts-settings.jsx:54
 msgid "Account"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:58
+#: src/components/shortcuts-settings.jsx:57
 msgid "Hashtag"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:66
+#: src/components/shortcuts-settings.jsx:65
 msgid "List ID"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:73
+#: src/components/shortcuts-settings.jsx:72
 msgid "Local only"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:78
-#: src/components/shortcuts-settings.jsx:87
-#: src/components/shortcuts-settings.jsx:125
-#: src/pages/login.jsx:231
+#: src/components/shortcuts-settings.jsx:77
+#: src/components/shortcuts-settings.jsx:86
+#: src/components/shortcuts-settings.jsx:124
 msgid "Server"
 msgstr "Server"
 
-#: src/components/shortcuts-settings.jsx:81
-#: src/components/shortcuts-settings.jsx:90
-#: src/components/shortcuts-settings.jsx:128
+#: src/components/shortcuts-settings.jsx:80
+#: src/components/shortcuts-settings.jsx:89
+#: src/components/shortcuts-settings.jsx:127
 msgid "Optional, e.g. mastodon.social"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:96
+#: src/components/shortcuts-settings.jsx:95
 msgid "Search term"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:99
-msgid "Optional, unless for multi-column mode"
-msgstr ""
+#: src/components/shortcuts-settings.jsx:98
+msgid "Optional"
+msgstr "Optional"
 
-#: src/components/shortcuts-settings.jsx:116
+#: src/components/shortcuts-settings.jsx:115
 msgid "e.g. PixelArt (Max 5, space-separated)"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:120
+#: src/components/shortcuts-settings.jsx:119
 #: src/pages/hashtag.jsx:389
 msgid "Media only"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:252
-#: src/components/shortcuts.jsx:345
+#: src/components/shortcuts-settings.jsx:249
+#: src/components/shortcuts.jsx:364
 msgid "Shortcuts"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:260
+#: src/components/shortcuts-settings.jsx:257
 msgid "beta"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:266
+#: src/components/shortcuts-settings.jsx:263
 msgid "Specify a list of shortcuts that'll appear as:"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:272
+#: src/components/shortcuts-settings.jsx:269
 msgid "Floating button"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:277
+#: src/components/shortcuts-settings.jsx:274
 msgid "Tab/Menu bar"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:282
-msgid "Multi-column"
-msgstr ""
-
-#: src/components/shortcuts-settings.jsx:349
+#: src/components/shortcuts-settings.jsx:341
 msgid "Not available in current view mode"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:368
+#: src/components/shortcuts-settings.jsx:360
 #: src/pages/accounts.jsx:219
 msgid "Move up"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:384
+#: src/components/shortcuts-settings.jsx:376
 #: src/pages/accounts.jsx:234
 msgid "Move down"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:396
+#: src/components/shortcuts-settings.jsx:388
 #: src/components/status.jsx:1644
-#: src/pages/list.jsx:195
+#: src/pages/list.jsx:236
 msgid "Edit"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:417
+#: src/components/shortcuts-settings.jsx:409
 msgid "Add more than one shortcut/column to make this work."
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:428
-msgid "No columns yet. Tap on the Add column button."
-msgstr ""
-
-#: src/components/shortcuts-settings.jsx:429
+#: src/components/shortcuts-settings.jsx:418
 msgid "No shortcuts yet. Tap on the Add shortcut button."
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:432
+#: src/components/shortcuts-settings.jsx:420
 msgid "Not sure what to add?<0/>Try adding <1>Home / Following and Notifications</1> first."
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:460
-msgid "Max {SHORTCUTS_LIMIT} columns"
-msgstr ""
-
-#: src/components/shortcuts-settings.jsx:461
+#: src/components/shortcuts-settings.jsx:447
 msgid "Max {SHORTCUTS_LIMIT} shortcuts"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:475
+#: src/components/shortcuts-settings.jsx:461
 #: src/pages/accounts.jsx:360
 msgid "Import/export"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:485
-msgid "Add column…"
-msgstr ""
-
-#: src/components/shortcuts-settings.jsx:486
+#: src/components/shortcuts-settings.jsx:468
 msgid "Add shortcut…"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:533
-msgid "Specific list is optional. For multi-column mode, list is required, else the column will not be shown."
-msgstr ""
+#: src/components/shortcuts-settings.jsx:514
+msgid "Specific list is optional."
+msgstr "Specific list is optional."
 
-#: src/components/shortcuts-settings.jsx:534
-msgid "For multi-column mode, search term is required, else the column will not be shown."
-msgstr ""
-
-#: src/components/shortcuts-settings.jsx:535
+#: src/components/shortcuts-settings.jsx:515
 msgid "Multiple hashtags are supported. Space-separated."
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:604
+#: src/components/shortcuts-settings.jsx:585
 msgid "Edit shortcut"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:604
+#: src/components/shortcuts-settings.jsx:585
 msgid "Add shortcut"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:640
+#: src/components/shortcuts-settings.jsx:621
 msgid "Timeline"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:666
+#: src/components/shortcuts-settings.jsx:647
 msgid "List"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:806
+#: src/components/shortcuts-settings.jsx:798
 msgid "Import/Export <0>Shortcuts</0>"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:824
+#: src/components/shortcuts-settings.jsx:816
 msgid "Paste shortcuts here"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:860
+#: src/components/shortcuts-settings.jsx:852
 msgid "Downloading saved shortcuts from server…"
 msgstr "Downloading saved shortcuts from server…"
 
-#: src/components/shortcuts-settings.jsx:888
+#: src/components/shortcuts-settings.jsx:880
 msgid "Unable to download shortcuts"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:891
+#: src/components/shortcuts-settings.jsx:883
 msgid "Download shortcuts from server"
 msgstr "Download shortcuts from server"
 
-#: src/components/shortcuts-settings.jsx:960
+#: src/components/shortcuts-settings.jsx:952
 msgid "* Exists in current shortcuts"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:965
+#: src/components/shortcuts-settings.jsx:957
 msgid "List may not work if it's from a different account."
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:975
+#: src/components/shortcuts-settings.jsx:967
 msgid "Invalid settings format"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:983
+#: src/components/shortcuts-settings.jsx:975
 msgid "Append to current shortcuts?"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:986
+#: src/components/shortcuts-settings.jsx:978
 msgid "Only shortcuts that don’t exist in current shortcuts will be appended."
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:1008
+#: src/components/shortcuts-settings.jsx:1000
 msgid "No new shortcuts to import"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:1023
+#: src/components/shortcuts-settings.jsx:1015
 msgid "Shortcuts imported. Exceeded max {SHORTCUTS_LIMIT}, so the rest are not imported."
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:1024
-#: src/components/shortcuts-settings.jsx:1048
+#: src/components/shortcuts-settings.jsx:1016
+#: src/components/shortcuts-settings.jsx:1040
 msgid "Shortcuts imported"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:1034
+#: src/components/shortcuts-settings.jsx:1026
 msgid "Import & append…"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:1042
+#: src/components/shortcuts-settings.jsx:1034
 msgid "Override current shortcuts?"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:1043
+#: src/components/shortcuts-settings.jsx:1035
 msgid "Import shortcuts?"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:1057
+#: src/components/shortcuts-settings.jsx:1049
 msgid "or override…"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:1057
+#: src/components/shortcuts-settings.jsx:1049
 msgid "Import…"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:1081
+#: src/components/shortcuts-settings.jsx:1073
 msgid "Shortcuts copied"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:1084
+#: src/components/shortcuts-settings.jsx:1076
 msgid "Unable to copy shortcuts"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:1136
+#: src/components/shortcuts-settings.jsx:1128
 msgid "Saving shortcuts to server…"
 msgstr "Saving shortcuts to server…"
 
-#: src/components/shortcuts-settings.jsx:1143
+#: src/components/shortcuts-settings.jsx:1135
 msgid "Shortcuts saved"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:1148
+#: src/components/shortcuts-settings.jsx:1140
 msgid "Unable to save shortcuts"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:1151
+#: src/components/shortcuts-settings.jsx:1143
 msgid "Sync to server"
 msgstr "Sync to server"
 
-#: src/components/shortcuts-settings.jsx:1166
+#: src/components/shortcuts-settings.jsx:1158
 msgid "Shortcut settings copied"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:1169
+#: src/components/shortcuts-settings.jsx:1161
 msgid "Unable to copy shortcut settings"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:1199
+#: src/components/shortcuts-settings.jsx:1191
 msgid "Share"
 msgstr ""
 
 #. placeholder {0}: shortcutsStr.length
-#: src/components/shortcuts-settings.jsx:1205
+#: src/components/shortcuts-settings.jsx:1197
 msgid "{0, plural, one {# character} other {# characters}}"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:1217
+#: src/components/shortcuts-settings.jsx:1209
 msgid "Raw Shortcuts JSON"
 msgstr ""
 
-#: src/components/shortcuts-settings.jsx:1230
+#: src/components/shortcuts-settings.jsx:1222
 msgid "Import/export settings from/to server (Very experimental)"
 msgstr "Import/export settings from/to server (Very experimental)"
 
@@ -2625,9 +2602,9 @@ msgid "You are not allowed to quote this post"
 msgstr "You are not allowed to quote this post"
 
 #: src/components/status.jsx:370
+#: src/components/status.jsx:3232
 #: src/components/status.jsx:3233
 #: src/components/status.jsx:3234
-#: src/components/status.jsx:3235
 msgid "Post unavailable"
 msgstr "Post unavailable"
 
@@ -2694,13 +2671,13 @@ msgstr "Only <0>@{0}</0>"
 
 #: src/components/status.jsx:1195
 #: src/components/status.jsx:1273
-#: src/components/status.jsx:2966
-#: src/components/status.jsx:3030
+#: src/components/status.jsx:2965
+#: src/components/status.jsx:3029
 msgid "Unboost"
 msgstr ""
 
 #: src/components/status.jsx:1234
-#: src/components/status.jsx:3015
+#: src/components/status.jsx:3014
 msgid "Quote with link"
 msgstr "Quote with link"
 
@@ -2717,31 +2694,31 @@ msgid "Boosted @{0}'s post"
 msgstr "Boosted @{0}'s post"
 
 #: src/components/status.jsx:1275
-#: src/components/status.jsx:3029
+#: src/components/status.jsx:3028
 msgid "Boost/Quote…"
 msgstr "Boost/Quote…"
 
 #: src/components/status.jsx:1276
-#: src/components/status.jsx:3029
+#: src/components/status.jsx:3028
 msgid "Boost…"
 msgstr ""
 
 #: src/components/status.jsx:1288
-#: src/components/status.jsx:2193
-#: src/components/status.jsx:3049
+#: src/components/status.jsx:2192
+#: src/components/status.jsx:3048
 msgid "Unlike"
 msgstr ""
 
 #: src/components/status.jsx:1289
+#: src/components/status.jsx:2192
 #: src/components/status.jsx:2193
-#: src/components/status.jsx:2194
+#: src/components/status.jsx:3048
 #: src/components/status.jsx:3049
-#: src/components/status.jsx:3050
 msgid "Like"
 msgstr ""
 
 #: src/components/status.jsx:1298
-#: src/components/status.jsx:3064
+#: src/components/status.jsx:3063
 msgid "Unbookmark"
 msgstr ""
 
@@ -2864,111 +2841,111 @@ msgstr "Remove quote…"
 msgid "Report post…"
 msgstr ""
 
-#: src/components/status.jsx:2194
-#: src/components/status.jsx:2230
-#: src/components/status.jsx:3050
+#: src/components/status.jsx:2193
+#: src/components/status.jsx:2229
+#: src/components/status.jsx:3049
 msgid "Liked"
 msgstr ""
 
-#: src/components/status.jsx:2227
-#: src/components/status.jsx:3032
+#: src/components/status.jsx:2226
+#: src/components/status.jsx:3031
 msgid "Boosted"
 msgstr ""
 
-#: src/components/status.jsx:2237
-#: src/components/status.jsx:3065
+#: src/components/status.jsx:2236
+#: src/components/status.jsx:3064
 msgid "Bookmarked"
 msgstr ""
 
-#: src/components/status.jsx:2241
+#: src/components/status.jsx:2240
 msgid "Pinned"
 msgstr ""
 
-#: src/components/status.jsx:2298
-#: src/components/status.jsx:2800
+#: src/components/status.jsx:2297
+#: src/components/status.jsx:2799
 msgid "Deleted"
 msgstr ""
 
-#: src/components/status.jsx:2336
-#: src/components/status.jsx:2403
+#: src/components/status.jsx:2335
+#: src/components/status.jsx:2402
 msgid "{repliesCount, plural, one {# reply} other {# replies}}"
 msgstr ""
 
-#: src/components/status.jsx:2348
-#: src/components/status.jsx:2415
-#: src/components/status.jsx:2832
+#: src/components/status.jsx:2347
+#: src/components/status.jsx:2414
+#: src/components/status.jsx:2831
 msgid "Edited"
 msgstr ""
 
-#: src/components/status.jsx:2510
-#: src/components/status.jsx:2572
-#: src/components/status.jsx:2679
+#: src/components/status.jsx:2509
+#: src/components/status.jsx:2571
+#: src/components/status.jsx:2678
 msgid "Show less"
 msgstr ""
 
-#: src/components/status.jsx:2510
-#: src/components/status.jsx:2572
+#: src/components/status.jsx:2509
+#: src/components/status.jsx:2571
 msgid "Show content"
 msgstr ""
 
 #. placeholder {0}: filterInfo.titlesStr
 #. placeholder {0}: filterInfo?.titlesStr
-#: src/components/status.jsx:2675
+#: src/components/status.jsx:2674
 #: src/pages/catchup.jsx:2051
 msgid "Filtered: {0}"
 msgstr "Filtered: {0}"
 
-#: src/components/status.jsx:2679
+#: src/components/status.jsx:2678
 msgid "Show media"
 msgstr ""
 
-#: src/components/status.jsx:2918
-#: src/components/status.jsx:2930
+#: src/components/status.jsx:2917
+#: src/components/status.jsx:2929
 msgid "Comments"
 msgstr ""
 
-#: src/components/status.jsx:3231
+#: src/components/status.jsx:3230
 msgid "Post hidden by your filters"
 msgstr "Post hidden by your filters"
 
-#: src/components/status.jsx:3232
+#: src/components/status.jsx:3231
 msgid "Post pending"
 msgstr "Post pending"
 
-#: src/components/status.jsx:3236
+#: src/components/status.jsx:3235
 msgid "Post removed by author"
 msgstr "Post removed by author"
 
-#: src/components/status.jsx:3237
+#: src/components/status.jsx:3236
 msgid "Post hidden because you've blocked @{name}."
 msgstr "Post hidden because you've blocked @{name}."
 
-#: src/components/status.jsx:3239
+#: src/components/status.jsx:3238
 msgid "Post hidden because you've blocked {domain}."
 msgstr "Post hidden because you've blocked {domain}."
 
-#: src/components/status.jsx:3240
+#: src/components/status.jsx:3239
 msgid "Post hidden because you've muted @{name}."
 msgstr "Post hidden because you've muted @{name}."
 
-#: src/components/status.jsx:3315
+#: src/components/status.jsx:3314
 msgid "Show anyway"
 msgstr "Show anyway"
 
-#: src/components/status.jsx:3460
+#: src/components/status.jsx:3459
 msgid "Edit History"
 msgstr ""
 
-#: src/components/status.jsx:3464
+#: src/components/status.jsx:3463
 msgid "Failed to load history"
 msgstr ""
 
-#: src/components/status.jsx:3469
+#: src/components/status.jsx:3468
 msgid "Loading…"
 msgstr ""
 
 #. [Name] [Visibility icon] boosted
-#: src/components/status.jsx:3601
+#: src/components/status.jsx:3600
 msgid "<0/> <1/> boosted"
 msgstr "<0/> <1/> boosted"
 
@@ -3070,7 +3047,7 @@ msgstr "Login required."
 #: src/compose.jsx:96
 #: src/pages/annual-report.jsx:186
 #: src/pages/http-route.jsx:91
-#: src/pages/login.jsx:309
+#: src/pages/login.jsx:327
 msgid "Go home"
 msgstr ""
 
@@ -3641,14 +3618,14 @@ msgstr ""
 msgid "No hashtags followed yet."
 msgstr ""
 
-#: src/pages/following.jsx:158
-#: src/pages/following2.jsx:135
+#: src/pages/following.jsx:166
+#: src/pages/following2.jsx:143
 msgid "Nothing to see here."
 msgstr ""
 
-#: src/pages/following.jsx:159
-#: src/pages/following2.jsx:136
-#: src/pages/list.jsx:109
+#: src/pages/following.jsx:167
+#: src/pages/following2.jsx:144
+#: src/pages/list.jsx:127
 msgid "Unable to load posts."
 msgstr ""
 
@@ -3767,11 +3744,11 @@ msgstr "Go to another server…"
 msgid "Go to my server (<0>{currentInstance}</0>)"
 msgstr "Go to my server (<0>{currentInstance}</0>)"
 
-#: src/pages/home.jsx:239
+#: src/pages/home.jsx:248
 msgid "Unable to fetch notifications."
 msgstr ""
 
-#: src/pages/home.jsx:260
+#: src/pages/home.jsx:269
 msgid "<0>New</0> <1>Follow Requests</1>"
 msgstr ""
 
@@ -3783,61 +3760,46 @@ msgstr ""
 msgid "Unable to resolve URL"
 msgstr ""
 
-#: src/pages/list.jsx:108
+#: src/pages/list.jsx:126
 msgid "Nothing yet."
 msgstr ""
 
-#: src/pages/list.jsx:201
-#: src/pages/list.jsx:307
+#: src/pages/list.jsx:242
+#: src/pages/list.jsx:350
 msgid "Manage members"
 msgstr ""
 
 #. placeholder {0}: account.username
-#: src/pages/list.jsx:342
+#: src/pages/list.jsx:385
 msgid "Remove <0>@{0}</0> from list?"
 msgstr ""
 
-#: src/pages/list.jsx:388
+#: src/pages/list.jsx:431
 msgid "Remove…"
 msgstr ""
 
-#. placeholder {0}: lists.length
-#: src/pages/lists.jsx:115
+#. placeholder {0}: userLists.length
+#: src/pages/lists.jsx:140
 msgid "{0, plural, one {# list} other {# lists}}"
 msgstr ""
 
-#: src/pages/lists.jsx:135
-msgid "No lists yet."
-msgstr ""
+#. placeholder {0}: feeds.length
+#: src/pages/lists.jsx:148
+msgid "{0, plural, one {# feed} other {# feeds}}"
+msgstr "{0, plural, one {# feed} other {# feeds}}"
 
-#: src/pages/login.jsx:125
-#: src/pages/login.jsx:137
+#: src/pages/lists.jsx:169
+msgid "No lists or feeds yet."
+msgstr "No lists or feeds yet."
+
+#: src/pages/login.jsx:135
+#: src/pages/login.jsx:147
 msgid "Failed to register application"
 msgstr "Failed to register application"
 
-#: src/pages/login.jsx:246
-msgid "server domain"
-msgstr "server domain"
-
-#: src/pages/login.jsx:271
-msgid "e.g. “mastodon.social”"
-msgstr ""
-
-#: src/pages/login.jsx:282
-msgid "Failed to log in. Please try again or try another server."
-msgstr "Failed to log in. Please try again or try another server."
-
-#: src/pages/login.jsx:294
-msgid "Continue with {selectedInstanceText}"
-msgstr ""
-
-#: src/pages/login.jsx:295
-msgid "Continue"
-msgstr ""
-
-#: src/pages/login.jsx:303
-msgid "Don't have an account? Create one!"
-msgstr ""
+#: src/pages/login.jsx:318
+msgid "Failed to log in. Please check your handle and app password."
+msgstr "Failed to log in. Please check your handle and app password."
 
 #: src/pages/mentions.jsx:25
 msgid "Private mentions"
@@ -4496,87 +4458,87 @@ msgstr ""
 msgid "No trending posts."
 msgstr ""
 
-#: src/pages/welcome.jsx:52
-msgid "A minimalistic opinionated Mastodon web client."
-msgstr ""
+#: src/pages/welcome.jsx:51
+msgid "A minimalistic opinionated Bluesky web client."
+msgstr "A minimalistic opinionated Bluesky web client."
 
-#: src/pages/welcome.jsx:63
-msgid "Log in with Mastodon"
-msgstr ""
+#: src/pages/welcome.jsx:62
+msgid "Log in with Bluesky"
+msgstr "Log in with Bluesky"
 
-#: src/pages/welcome.jsx:69
+#: src/pages/welcome.jsx:68
 msgid "Sign up"
 msgstr ""
 
-#: src/pages/welcome.jsx:76
-msgid "Connect your existing Mastodon/Fediverse account.<0/>Your credentials are not stored on this server."
-msgstr ""
+#: src/pages/welcome.jsx:75
+msgid "Connect your existing Bluesky account.<0/>Your credentials are not stored on this server."
+msgstr "Connect your existing Bluesky account.<0/>Your credentials are not stored on this server."
 
-#: src/pages/welcome.jsx:96
+#: src/pages/welcome.jsx:95
 msgid "Screenshot of Phanpy home timeline on mobile device"
 msgstr "Screenshot of Phanpy home timeline on mobile device"
 
-#: src/pages/welcome.jsx:113
+#: src/pages/welcome.jsx:112
 msgid "Screenshot of Phanpy home timeline on tablet device"
 msgstr "Screenshot of Phanpy home timeline on tablet device"
 
-#: src/pages/welcome.jsx:127
+#: src/pages/welcome.jsx:126
 msgid "Screenshot of Boosts Carousel"
 msgstr ""
 
-#: src/pages/welcome.jsx:134
+#: src/pages/welcome.jsx:133
 msgid "Boosts Carousel"
 msgstr ""
 
-#: src/pages/welcome.jsx:137
+#: src/pages/welcome.jsx:136
 msgid "Visually separate original posts and re-shared posts (boosted posts)."
 msgstr ""
 
-#: src/pages/welcome.jsx:147
+#: src/pages/welcome.jsx:146
 msgid "Screenshot of Catch-up"
 msgstr "Screenshot of Catch-up"
 
-#: src/pages/welcome.jsx:157
+#: src/pages/welcome.jsx:156
 msgid "A separate timeline for followings. Email-inspired interface to sort and filter posts."
 msgstr "A separate timeline for followings. Email-inspired interface to sort and filter posts."
 
-#: src/pages/welcome.jsx:167
+#: src/pages/welcome.jsx:166
 msgid "Screenshot of nested comments thread"
 msgstr ""
 
-#: src/pages/welcome.jsx:174
+#: src/pages/welcome.jsx:173
 msgid "Nested comments thread"
 msgstr ""
 
-#: src/pages/welcome.jsx:177
+#: src/pages/welcome.jsx:176
 msgid "Effortlessly follow conversations. Semi-collapsible replies."
 msgstr ""
 
-#: src/pages/welcome.jsx:186
+#: src/pages/welcome.jsx:185
 msgid "Screenshot of multi-column UI"
 msgstr ""
 
-#: src/pages/welcome.jsx:193
+#: src/pages/welcome.jsx:192
 msgid "Single or multi-column"
 msgstr ""
 
-#: src/pages/welcome.jsx:196
+#: src/pages/welcome.jsx:195
 msgid "By default, single column for zen-mode seekers. Configurable multi-column for power users."
 msgstr ""
 
-#: src/pages/welcome.jsx:206
+#: src/pages/welcome.jsx:205
 msgid "Screenshot of multi-hashtag timeline with a form to add more hashtags"
 msgstr ""
 
-#: src/pages/welcome.jsx:213
+#: src/pages/welcome.jsx:212
 msgid "Multi-hashtag timeline"
 msgstr ""
 
-#: src/pages/welcome.jsx:216
+#: src/pages/welcome.jsx:215
 msgid "Up to 5 hashtags combined into a single timeline."
 msgstr ""
 
-#: src/pages/welcome.jsx:231
+#: src/pages/welcome.jsx:230
 msgid "<0>Built</0> by <1>@cheeaun</1>. <2>Privacy Policy</2>."
 msgstr ""
 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -24,6 +24,19 @@ if (import.meta.env.DEV) {
   import('preact/debug');
 }
 
+if (import.meta.env.DEV && 'serviceWorker' in navigator) {
+  navigator.serviceWorker
+    .getRegistrations()
+    .then((registrations) => {
+      registrations.forEach((registration) => {
+        registration.unregister();
+      });
+    })
+    .catch(() => {});
+}
+
+document.getElementById('boot-status')?.remove();
+
 render(
   <I18nProvider i18n={i18n}>
     <HashRouter>

--- a/src/pages/following.jsx
+++ b/src/pages/following.jsx
@@ -6,6 +6,7 @@ import Timeline from '../components/timeline';
 import { api } from '../utils/api';
 import { filteredItems } from '../utils/filters';
 import states, { getStatus, saveStatus } from '../utils/states';
+import store from '../utils/store';
 import supports from '../utils/supports';
 import {
   assignFollowedTags,
@@ -33,6 +34,13 @@ function Following({ title, path, id, ...props }) {
   const homeIterable = useRef();
   const homeIterator = useRef();
   const latestItem = useRef();
+
+  useEffect(() => {
+    if (path === '/') return;
+    const homeTimeline = { type: 'following' };
+    store.account.set('homeTimeline', homeTimeline);
+    states.homeTimeline = homeTimeline;
+  }, [path]);
 
   // Streaming only happens after instance is initialized
   useEffect(() => {

--- a/src/pages/following2.jsx
+++ b/src/pages/following2.jsx
@@ -4,7 +4,8 @@ import { useEffect, useState } from 'preact/hooks';
 import Timeline2 from '../components/timeline2';
 import { api } from '../utils/api';
 import { filteredItems } from '../utils/filters';
-import { getStatus, saveStatus } from '../utils/states';
+import states, { getStatus, saveStatus } from '../utils/states';
+import store from '../utils/store';
 import supports from '../utils/supports';
 import { assignFollowedTags, dedupeBoosts } from '../utils/timeline-utils';
 import useTitle from '../utils/useTitle';
@@ -23,6 +24,13 @@ function Following2({ title, path, id, ...props }) {
   );
   const { masto, streaming, instance, client } = api();
   const [streamingClient, setStreamingClient] = useState(streaming);
+
+  useEffect(() => {
+    if (path === '/') return;
+    const homeTimeline = { type: 'following' };
+    store.account.set('homeTimeline', homeTimeline);
+    states.homeTimeline = homeTimeline;
+  }, [path]);
 
   // Streaming only happens after instance is initialized
   useEffect(() => {

--- a/src/pages/home.jsx
+++ b/src/pages/home.jsx
@@ -7,7 +7,6 @@ import { memo } from 'preact/compat';
 import { useEffect, useRef, useState } from 'preact/hooks';
 import { useSnapshot } from 'valtio';
 
-import Columns from '../components/columns';
 import Icon from '../components/icon';
 import Link from '../components/link';
 import Loader from '../components/loader';
@@ -22,6 +21,7 @@ import { getCurrentAccountNS } from '../utils/store-utils';
 
 import Following from './following';
 import Following2 from './following2';
+import List from './list';
 import {
   getGroupedNotifications,
   mastoFetchNotifications,
@@ -48,17 +48,26 @@ function Home() {
   if (!expTimeline2.current) {
     expTimeline2.current = store.local.get('experiments-timeline2') ?? false;
   }
+  const homeTimeline =
+    snapStates.homeTimeline || store.account.get('homeTimeline');
+  const defaultFeedID =
+    homeTimeline?.type === 'feed' && homeTimeline?.id ? homeTimeline.id : null;
+  const defaultFollowing = homeTimeline?.type === 'following';
 
   return (
     <>
-      {(snapStates.settings.shortcutsViewMode === 'multi-column' ||
-        (!snapStates.settings.shortcutsViewMode &&
-          snapStates.settings.shortcutsColumnsMode)) &&
-      !!snapStates.shortcuts?.length ? (
-        <Columns />
-      ) : expTimeline2.current ? (
+      {defaultFeedID ? (
+        <List id={defaultFeedID} />
+      ) : expTimeline2.current && !defaultFollowing ? (
         <Following2
           title={_(msg`Home`)}
+          path="/"
+          id="home"
+          headerStart={false}
+          headerEnd={<NotificationsLink />}
+        />
+      ) : defaultFollowing ? (
+        <Following
           path="/"
           id="home"
           headerStart={false}

--- a/src/pages/list.jsx
+++ b/src/pages/list.jsx
@@ -9,6 +9,7 @@ import { useSnapshot } from 'valtio';
 
 import AccountBlock from '../components/account-block';
 import Icon from '../components/icon';
+import Link from '../components/link';
 import ListAddEdit from '../components/list-add-edit';
 import ListExclusiveBadge from '../components/list-exclusive-badge';
 import MenuConfirm from '../components/menu-confirm';
@@ -18,8 +19,14 @@ import Modal from '../components/modal';
 import Timeline from '../components/timeline';
 import { api } from '../utils/api';
 import { filteredItems } from '../utils/filters';
-import { getList, getLists } from '../utils/lists';
+import {
+  getList,
+  getLists,
+  isFeedList,
+  splitListsAndFeeds,
+} from '../utils/lists';
 import states, { saveStatus } from '../utils/states';
+import store from '../utils/store';
 import useTitle from '../utils/useTitle';
 
 const LIMIT = 20;
@@ -28,7 +35,8 @@ function List(props) {
   const { t } = useLingui();
   const snapStates = useSnapshot(states);
   const { masto, instance } = api();
-  const id = props?.id || useParams()?.id;
+  const params = useParams();
+  const id = props?.id || params?.id;
   // const navigate = useNavigate();
   const latestItem = useRef();
   // const [reloadCount, reload] = useReducer((c) => c + 1, 0);
@@ -82,6 +90,8 @@ function List(props) {
   const [lists, setLists] = useState([]);
 
   const [list, setList] = useState({ title: 'List' });
+  const isFeed = isFeedList(list);
+  const { lists: menuLists, feeds: menuFeeds } = splitListsAndFeeds(lists);
   // const [title, setTitle] = useState(`List`);
   useTitle(list.title, `/l/:id`);
   useEffect(() => {
@@ -89,6 +99,14 @@ function List(props) {
       try {
         const list = await getList(id);
         setList(list);
+        if (isFeedList(list)) {
+          const homeTimeline = {
+            type: 'feed',
+            id: list.id,
+          };
+          store.account.set('homeTimeline', homeTimeline);
+          states.homeTimeline = homeTimeline;
+        }
         // setTitle(list.title);
       } catch (e) {
         console.error(e);
@@ -122,9 +140,10 @@ function List(props) {
           // </Link>
           <Menu2
             overflow="auto"
+            menuClassName="lists-picker-menu"
             menuButton={
               <button type="button" class="plain">
-                <Icon icon="list" size="l" alt={t`Lists`} />
+                <Icon icon="list" size="l" alt={t`Lists & Feeds`} />
                 <Icon icon="chevron-down" size="s" />
               </button>
             }
@@ -136,13 +155,16 @@ function List(props) {
           >
             <MenuLink to="/l">
               <span>
-                <Trans>All Lists</Trans>
+                <Trans>Lists & Feeds</Trans>
               </span>
             </MenuLink>
-            {lists?.length > 0 && (
+            {menuLists?.length > 0 && (
               <>
                 <MenuDivider />
-                {lists.map((list) => (
+                <MenuHeader className="plain">
+                  <Trans>Lists</Trans>
+                </MenuHeader>
+                {menuLists.map((list) => (
                   <MenuLink key={list.id} to={`/l/${list.id}`}>
                     <span>
                       {list.title}
@@ -157,51 +179,72 @@ function List(props) {
                 ))}
               </>
             )}
+            {menuFeeds?.length > 0 && (
+              <>
+                <MenuDivider />
+                <MenuHeader className="plain">
+                  <Trans>Feeds</Trans>
+                </MenuHeader>
+                {menuFeeds.map((list) => (
+                  <MenuLink key={list.id} to={`/l/${list.id}`}>
+                    <Icon icon="sparkles" />
+                    <span>{list.title}</span>
+                  </MenuLink>
+                ))}
+              </>
+            )}
           </Menu2>
         }
         headerEnd={
-          <Menu2
-            portal
-            setDownOverflow
-            overflow="auto"
-            viewScroll="close"
-            position="anchor"
-            menuButton={
-              <button type="button" class="plain">
-                <Icon icon="more" size="l" alt={t`More`} />
-              </button>
-            }
-          >
-            {list?.exclusive && (
-              <>
-                <MenuHeader className="plain">
-                  <ListExclusiveBadge />{' '}
-                  <Trans>
-                    Posts on this list are hidden from Home/Following
-                  </Trans>
-                </MenuHeader>
-                <MenuDivider />
-              </>
+          <>
+            <Link to="/notifications" class="button plain notifications-button">
+              <Icon icon="notification" size="l" alt={t`Notifications`} />
+            </Link>
+            {!isFeed && (
+              <Menu2
+                portal
+                setDownOverflow
+                overflow="auto"
+                viewScroll="close"
+                position="anchor"
+                menuButton={
+                  <button type="button" class="plain">
+                    <Icon icon="more" size="l" alt={t`More`} />
+                  </button>
+                }
+              >
+                {list?.exclusive && (
+                  <>
+                    <MenuHeader className="plain">
+                      <ListExclusiveBadge />{' '}
+                      <Trans>
+                        Posts on this list are hidden from Home/Following
+                      </Trans>
+                    </MenuHeader>
+                    <MenuDivider />
+                  </>
+                )}
+                <MenuItem
+                  onClick={() =>
+                    setShowListAddEditModal({
+                      list,
+                    })
+                  }
+                >
+                  <Icon icon="pencil" size="l" />
+                  <span>
+                    <Trans>Edit</Trans>
+                  </span>
+                </MenuItem>
+                <MenuItem onClick={() => setShowManageMembersModal(true)}>
+                  <Icon icon="group" size="l" />
+                  <span>
+                    <Trans>Manage members</Trans>
+                  </span>
+                </MenuItem>
+              </Menu2>
             )}
-            <MenuItem
-              onClick={() =>
-                setShowListAddEditModal({
-                  list,
-                })
-              }
-            >
-              <Icon icon="pencil" size="l" />
-              <span>
-                <Trans>Edit</Trans>
-              </span>
-            </MenuItem>
-            <MenuItem onClick={() => setShowManageMembersModal(true)}>
-              <Icon icon="group" size="l" />
-              <span>
-                <Trans>Manage members</Trans>
-              </span>
-            </MenuItem>
-          </Menu2>
+          </>
         }
       />
       {showListAddEditModal && (

--- a/src/pages/lists.css
+++ b/src/pages/lists.css
@@ -2,6 +2,12 @@
   display: none;
 }
 
+.lists-picker-menu {
+  max-height: min(70vh, 32rem);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
 .list-form {
   padding: 8px 0;
   display: flex;

--- a/src/pages/lists.jsx
+++ b/src/pages/lists.jsx
@@ -10,12 +10,12 @@ import ListExclusiveBadge from '../components/list-exclusive-badge';
 import Loader from '../components/loader';
 import Modal from '../components/modal';
 import NavMenu from '../components/nav-menu';
-import { fetchLists } from '../utils/lists';
+import { fetchLists, splitListsAndFeeds } from '../utils/lists';
 import useTitle from '../utils/useTitle';
 
 function Lists() {
   const { t } = useLingui();
-  useTitle(t`Lists`, `/l`);
+  useTitle(t`Lists & Feeds`, `/l`);
   const [uiState, setUIState] = useState('default');
 
   const [reloadCount, reload] = useReducer((c) => c + 1, 0);
@@ -37,7 +37,8 @@ function Lists() {
 
   const [showListAddEditModal, setShowListAddEditModal] = useState(false);
 
-  const hasExclusiveLists = lists.some((list) => list.exclusive);
+  const { lists: userLists, feeds } = splitListsAndFeeds(lists);
+  const hasExclusiveLists = userLists.some((list) => list.exclusive);
 
   return (
     <div id="lists-page" class="deck-container" tabIndex="-1">
@@ -51,7 +52,7 @@ function Lists() {
               </Link>
             </div>
             <h1>
-              <Trans>Lists</Trans>
+              <Trans>Lists & Feeds</Trans>
             </h1>
             <div class="header-side">
               <button
@@ -67,21 +68,26 @@ function Lists() {
         <main>
           {lists.length > 0 ? (
             <>
-              <ul class="link-list">
-                {lists.map((list) => (
-                  <li>
-                    <Link to={`/l/${list.id}`}>
-                      <Icon icon="list" />{' '}
-                      <span>
-                        {list.title}
-                        {list.exclusive && (
-                          <>
-                            {' '}
-                            <ListExclusiveBadge insignificant />
-                          </>
-                        )}
-                      </span>
-                      {/* <button
+              {userLists.length > 0 && (
+                <>
+                  <h2 class="timeline-header">
+                    <Trans>Lists</Trans>
+                  </h2>
+                  <ul class="link-list">
+                    {userLists.map((list) => (
+                      <li>
+                        <Link to={`/l/${list.id}`}>
+                          <Icon icon="list" />{' '}
+                          <span>
+                            {list.title}
+                            {list.exclusive && (
+                              <>
+                                {' '}
+                                <ListExclusiveBadge insignificant />
+                              </>
+                            )}
+                          </span>
+                          {/* <button
                       type="button"
                       class="plain"
                       onClick={(e) => {
@@ -94,10 +100,28 @@ function Lists() {
                     >
                       <Icon icon="pencil" />
                     </button> */}
-                    </Link>
-                  </li>
-                ))}
-              </ul>
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                </>
+              )}
+              {feeds.length > 0 && (
+                <>
+                  <h2 class="timeline-header">
+                    <Trans>Feeds</Trans>
+                  </h2>
+                  <ul class="link-list">
+                    {feeds.map((feed) => (
+                      <li>
+                        <Link to={`/l/${feed.id}`}>
+                          <Icon icon="sparkles" /> <span>{feed.title}</span>
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                </>
+              )}
               {lists.length > 1 && (
                 <footer class="ui-state">
                   {hasExclusiveLists && (
@@ -112,11 +136,21 @@ function Lists() {
                   )}
                   <p>
                     <small class="insignificant">
-                      <Plural
-                        value={lists.length}
-                        one="# list"
-                        other="# lists"
-                      />
+                      {userLists.length > 0 && (
+                        <Plural
+                          value={userLists.length}
+                          one="# list"
+                          other="# lists"
+                        />
+                      )}
+                      {userLists.length > 0 && feeds.length > 0 && ' · '}
+                      {feeds.length > 0 && (
+                        <Plural
+                          value={feeds.length}
+                          one="# feed"
+                          other="# feeds"
+                        />
+                      )}
                     </small>
                   </p>
                 </footer>
@@ -132,7 +166,7 @@ function Lists() {
             </p>
           ) : (
             <p class="ui-state">
-              <Trans>No lists yet.</Trans>
+              <Trans>No lists or feeds yet.</Trans>
             </p>
           )}
         </main>

--- a/src/pages/login.jsx
+++ b/src/pages/login.jsx
@@ -11,6 +11,12 @@ import LangSelector from '../components/lang-selector';
 import Link from '../components/link';
 import Loader from '../components/loader';
 import instancesListURL from '../data/instances.json?url';
+import { initClient, initInstance, initPreferences } from '../utils/api';
+import {
+  BSKY_INSTANCE,
+  BSKY_PDS,
+  loginAtproto,
+} from '../utils/atproto-adapter';
 import {
   getAuthorizationURL,
   getPKCEAuthorizationURL,
@@ -22,6 +28,8 @@ import store from '../utils/store';
 import {
   getCredentialApplication,
   hasAccountInInstance,
+  saveAccount,
+  setCurrentAccountID,
   storeCredentialApplication,
 } from '../utils/store-utils';
 import useTitle from '../utils/useTitle';
@@ -34,6 +42,8 @@ function Login() {
   const instanceURLRef = useRef();
   const cachedInstanceURL = store.local.get('instanceURL');
   const [uiState, setUIState] = useState('default');
+  const [bskyIdentifier, setBskyIdentifier] = useState('');
+  const [bskyPassword, setBskyPassword] = useState('');
   const [searchParams] = useSearchParams();
   const instance = searchParams.get('instance');
   const submit = searchParams.get('submit');
@@ -212,6 +222,45 @@ function Login() {
     submitInstance(selectedInstanceText);
   };
 
+  const submitBluesky = (e) => {
+    e.preventDefault();
+    if (!bskyIdentifier || !bskyPassword) return;
+    (async () => {
+      setUIState('loading');
+      try {
+        const { account, session, service } = await loginAtproto({
+          identifier: bskyIdentifier.trim(),
+          password: bskyPassword,
+          service: BSKY_PDS,
+        });
+        const accessToken = JSON.stringify({
+          type: 'atproto',
+          service,
+          session,
+        });
+        saveAccount({
+          info: account,
+          instanceURL: BSKY_INSTANCE,
+          accessToken,
+          atproto: true,
+          createdAt: Date.now(),
+        });
+        setCurrentAccountID(account.id);
+        const client = initClient({ instance: BSKY_INSTANCE, accessToken });
+        await Promise.allSettled([
+          initPreferences(client),
+          initInstance(client, BSKY_INSTANCE),
+        ]);
+        location.href = location.pathname || '/';
+      } catch (e) {
+        console.error(e);
+        setUIState('error');
+      } finally {
+        setUIState('default');
+      }
+    })();
+  };
+
   if (submit) {
     useEffect(() => {
       submitInstance(instance || selectedInstanceText);
@@ -220,90 +269,59 @@ function Login() {
 
   return (
     <main id="login" style={{ textAlign: 'center' }}>
-      <form onSubmit={onSubmit}>
+      <form onSubmit={submitBluesky}>
         <h1>
           <img src={logo} alt="" width="80" height="80" />
           <br />
           <Trans>Log in</Trans>
         </h1>
-        <label>
-          <p>
-            <Trans>Server</Trans>
-          </p>
-          <input
-            value={instanceText}
-            required
-            type="text"
-            class="large"
-            id="instanceURL"
-            ref={instanceURLRef}
-            disabled={uiState === 'loading'}
-            // list="instances-list"
-            autocorrect="off"
-            autocapitalize="off"
-            autocomplete="off"
-            spellCheck={false}
-            placeholder={t`server domain`}
-            enterKeyHint="go"
-            onInput={(e) => {
-              setInstanceText(e.target.value);
-            }}
-            dir="auto"
-          />
-          {instancesSuggestions?.length > 0 ? (
-            <ul id="instances-suggestions">
-              {instancesSuggestions.map((instance, i) => (
-                <li>
-                  <button
-                    type="button"
-                    class="plain5"
-                    onClick={() => {
-                      submitInstance(instance);
-                    }}
-                  >
-                    {instance}
-                  </button>
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <div id="instances-eg">
-              <Trans>e.g. &ldquo;mastodon.social&rdquo;</Trans>
-            </div>
-          )}
-          {/* <datalist id="instances-list">
-            {instancesList.map((instance) => (
-              <option value={instance} />
-            ))}
-          </datalist> */}
-        </label>
+        <section class="bsky-login">
+          <h2>Bluesky</h2>
+          <label>
+            <p>Handle or email</p>
+            <input
+              value={bskyIdentifier}
+              type="text"
+              class="large"
+              disabled={uiState === 'loading'}
+              autocorrect="off"
+              autocapitalize="off"
+              autocomplete="username"
+              spellCheck={false}
+              placeholder="alice.bsky.social"
+              onInput={(e) => setBskyIdentifier(e.target.value)}
+            />
+          </label>
+          <label>
+            <p>App password</p>
+            <input
+              value={bskyPassword}
+              type="password"
+              class="large"
+              disabled={uiState === 'loading'}
+              autocomplete="current-password"
+              onInput={(e) => setBskyPassword(e.target.value)}
+            />
+          </label>
+          <div>
+            <button
+              disabled={
+                uiState === 'loading' || !bskyIdentifier || !bskyPassword
+              }
+            >
+              Continue with Bluesky
+            </button>
+          </div>
+        </section>
         {uiState === 'error' && (
           <p class="error">
             <Trans>
-              Failed to log in. Please try again or try another server.
+              Failed to log in. Please check your handle and app password.
             </Trans>
           </p>
         )}
-        <div>
-          <button
-            disabled={
-              uiState === 'loading' || !instanceText || !selectedInstanceText
-            }
-          >
-            {selectedInstanceText
-              ? t`Continue with ${selectedInstanceText}`
-              : t`Continue`}
-          </button>{' '}
-        </div>
         <Loader hidden={uiState !== 'loading'} />
         <hr />
-        {!DEFAULT_INSTANCE && (
-          <p>
-            <a href="https://joinmastodon.org/servers" target="_blank">
-              <Trans>Don't have an account? Create one!</Trans>
-            </a>
-          </p>
-        )}
         <p>
           <Link to="/">
             <Trans>Go home</Trans>

--- a/src/pages/status-route.jsx
+++ b/src/pages/status-route.jsx
@@ -1,9 +1,11 @@
 import { useParams } from 'react-router-dom';
 
+import { encodeAtprotoID } from '../utils/atproto-route';
 import Status from './status';
 
 export default function StatusRoute() {
   const params = useParams();
-  const { id, instance } = params;
+  let { id, instance } = params;
+  if (id?.startsWith('at://')) id = encodeAtprotoID(id);
   return <Status id={id} instance={instance} />;
 }

--- a/src/pages/status-route.jsx
+++ b/src/pages/status-route.jsx
@@ -1,6 +1,7 @@
 import { useParams } from 'react-router-dom';
 
 import { encodeAtprotoID } from '../utils/atproto-route';
+
 import Status from './status';
 
 export default function StatusRoute() {

--- a/src/pages/welcome.jsx
+++ b/src/pages/welcome.jsx
@@ -16,7 +16,6 @@ import homeTabletLight from '../assets/screenshots/home-tablet-light@2x.png';
 
 import LangSelector from '../components/lang-selector';
 import Link from '../components/link';
-import states from '../utils/states';
 import useTitle from '../utils/useTitle';
 
 const {
@@ -49,7 +48,7 @@ function Welcome() {
             <img src={logoText} alt="Phanpy" width="180" height="52" />
           </h1>
           <p class="desc">
-            <Trans>A minimalistic opinionated Mastodon web client.</Trans>
+            <Trans>A minimalistic opinionated Bluesky web client.</Trans>
           </p>
           <p>
             <Link
@@ -60,7 +59,7 @@ function Welcome() {
               }
               class="button plain6"
             >
-              {DEFAULT_INSTANCE ? t`Log in` : t`Log in with Mastodon`}
+              {DEFAULT_INSTANCE ? t`Log in` : t`Log in with Bluesky`}
             </Link>
           </p>
           {DEFAULT_INSTANCE && DEFAULT_INSTANCE_REGISTRATION_URL && (
@@ -74,7 +73,7 @@ function Welcome() {
             <p class="insignificant">
               <small>
                 <Trans>
-                  Connect your existing Mastodon/Fediverse account.
+                  Connect your existing Bluesky account.
                   <br />
                   Your credentials are not stored on this server.
                 </Trans>
@@ -233,14 +232,7 @@ function Welcome() {
               Built
             </a>{' '}
             by{' '}
-            <a
-              href="https://mastodon.social/@cheeaun"
-              target="_blank"
-              onClick={(e) => {
-                e.preventDefault();
-                states.showAccount = 'cheeaun@mastodon.social';
-              }}
-            >
+            <a href="https://github.com/cheeaun" target="_blank">
               @cheeaun
             </a>
             .{' '}

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,13 +1,13 @@
 import { compareVersions, satisfies, validate } from 'compare-versions';
 import { createRestAPIClient, createStreamingAPIClient } from 'masto';
 
+import mem from '../utils/mem';
+
 import {
   atprotoInstanceInfo,
   BSKY_INSTANCE,
   createAtprotoClient,
 } from './atproto-adapter';
-import mem from '../utils/mem';
-
 import store from './store';
 import {
   getAccount,
@@ -116,7 +116,9 @@ export function initClient({ instance, accessToken }) {
 }
 
 export function isAtprotoInstance(instance) {
-  return instance === BSKY_INSTANCE || instance === 'atproto' || instance === 'bsky';
+  return (
+    instance === BSKY_INSTANCE || instance === 'atproto' || instance === 'bsky'
+  );
 }
 
 function parseAtprotoSession(accessToken) {

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,6 +1,11 @@
 import { compareVersions, satisfies, validate } from 'compare-versions';
 import { createRestAPIClient, createStreamingAPIClient } from 'masto';
 
+import {
+  atprotoInstanceInfo,
+  BSKY_INSTANCE,
+  createAtprotoClient,
+} from './atproto-adapter';
 import mem from '../utils/mem';
 
 import store from './store';
@@ -40,6 +45,52 @@ export function initClient({ instance, accessToken }) {
       .replace(/\/+$/, '')
       .toLowerCase();
   }
+  const atprotoSession = parseAtprotoSession(accessToken);
+  if (isAtprotoInstance(instance) || atprotoSession) {
+    instance = BSKY_INSTANCE;
+    let client;
+    let persistedAccessToken = accessToken;
+    const persistSession = (event, session) => {
+      if (!session || !persistedAccessToken) return;
+      const account = getAccountByAccessToken(persistedAccessToken);
+      if (!account) return;
+      const nextAccessToken = JSON.stringify({
+        type: 'atproto',
+        service: atprotoSession?.service,
+        session,
+      });
+      account.accessToken = nextAccessToken;
+      account.updatedAt = Date.now();
+      saveAccount(account);
+      if (accountApis[instance]?.[persistedAccessToken]) {
+        delete accountApis[instance][persistedAccessToken];
+      }
+      persistedAccessToken = nextAccessToken;
+      if (client) {
+        client.accessToken = nextAccessToken;
+        accountApis[instance][nextAccessToken] = client;
+      }
+    };
+    const masto = createAtprotoClient({
+      session: atprotoSession?.session,
+      service: atprotoSession?.service,
+      persistSession,
+    });
+    client = {
+      masto,
+      instance,
+      accessToken,
+      atproto: true,
+      onStreamingReady: function (callback) {
+        this._streamingCallback = callback;
+      },
+    };
+    apis[instance] = client;
+    if (!accountApis[instance]) accountApis[instance] = {};
+    if (accessToken) accountApis[instance][accessToken] = client;
+    return client;
+  }
+
   const url = instance ? `https://${instance}` : `https://${DEFAULT_INSTANCE}`;
 
   const masto = createRestAPIClient({
@@ -64,6 +115,20 @@ export function initClient({ instance, accessToken }) {
   return client;
 }
 
+export function isAtprotoInstance(instance) {
+  return instance === BSKY_INSTANCE || instance === 'atproto' || instance === 'bsky';
+}
+
+function parseAtprotoSession(accessToken) {
+  if (!accessToken) return null;
+  try {
+    const data = JSON.parse(accessToken);
+    return data?.type === 'atproto' ? data : null;
+  } catch (e) {
+    return null;
+  }
+}
+
 export function hasInstance(instance) {
   const instances = store.local.getJSON('instances') || {};
   return !!instances[instance];
@@ -73,6 +138,17 @@ export function hasInstance(instance) {
 // The config is needed for composing
 export async function initInstance(client, instance) {
   console.log('INIT INSTANCE', client, instance);
+  if (client.atproto) {
+    const instances = store.local.getJSON('instances') || {};
+    instances[BSKY_INSTANCE] = atprotoInstanceInfo();
+    store.local.setJSON('instances', instances);
+    const nodeInfos = store.local.getJSON('nodeInfos') || {};
+    nodeInfos[BSKY_INSTANCE] = {
+      software: { name: 'mastodon', version: '4.4.0' },
+    };
+    store.local.setJSON('nodeInfos', nodeInfos);
+    return;
+  }
   const { masto, accessToken } = client;
   // Request v2, fallback to v1 if fail
   let info;
@@ -180,6 +256,19 @@ export async function initInstance(client, instance) {
 
 // Get the account information and store it
 export async function initAccount(client, instance, accessToken, vapidKey) {
+  if (client.atproto) {
+    const atprotoAccount = await client.masto.v1.accounts.verifyCredentials();
+    setCurrentAccountID(atprotoAccount.id);
+    saveAccount({
+      info: atprotoAccount,
+      instanceURL: BSKY_INSTANCE,
+      accessToken,
+      vapidKey,
+      atproto: true,
+      createdAt: Date.now(),
+    });
+    return;
+  }
   const { masto } = client;
   const mastoAccount = await masto.v1.accounts.verifyCredentials();
 

--- a/src/utils/atproto-adapter.js
+++ b/src/utils/atproto-adapter.js
@@ -1,0 +1,2032 @@
+import { BskyAgent, RichText } from '@atproto/api';
+import { getPdsEndpoint } from '@atproto/common-web';
+
+import { encodeAtprotoID } from './atproto-route';
+
+const BSKY_APPVIEW = 'https://public.api.bsky.app';
+export const BSKY_PDS = 'https://bsky.social';
+export const BSKY_INSTANCE = 'bsky.social';
+const BSKY_DISCOVER_FEED =
+  'at://did:plc:z72i7hdynmk6r22z27h6tvur/app.bsky.feed.generator/whats-hot';
+const BSKY_VIDEO_SERVICE = 'https://video.bsky.app';
+const BSKY_VIDEO_SERVICE_DID = 'did:web:video.bsky.app';
+
+function getServiceAuthAudFromUrl(url) {
+  const { hostname } = new URL(url);
+  return `did:web:${hostname}`;
+}
+
+function createVideoEndpointUrl(route, params = {}) {
+  const url = new URL(BSKY_VIDEO_SERVICE);
+  url.pathname = route;
+  Object.entries(params).forEach(([key, value]) => {
+    url.searchParams.set(key, value);
+  });
+  return url.href;
+}
+
+async function getServiceAuthToken({ agent, aud, lxm, exp }) {
+  const res = await agent.com.atproto.server.getServiceAuth({
+    aud,
+    lxm,
+    exp,
+  });
+  return res.data.token;
+}
+
+async function uploadVideoBlob(agent, file) {
+  if (file.type !== 'video/mp4') {
+    throw new Error('Only MP4 video uploads are supported for Bluesky posts');
+  }
+  if (!agent.did) throw new Error('Missing Bluesky session');
+
+  if (!agent.sessionManager.pdsUrl) {
+    const session = await agent.com.atproto.server.getSession();
+    const pdsEndpoint = session.data.didDoc
+      ? getPdsEndpoint(session.data.didDoc)
+      : null;
+    if (pdsEndpoint) agent.sessionManager.pdsUrl = new URL(pdsEndpoint);
+  }
+
+  const uploadToken = await getServiceAuthToken({
+    agent,
+    aud: getServiceAuthAudFromUrl(agent.dispatchUrl),
+    lxm: 'com.atproto.repo.uploadBlob',
+    exp: Date.now() / 1000 + 60 * 30,
+  });
+  const uploadRes = await fetch(
+    createVideoEndpointUrl('/xrpc/app.bsky.video.uploadVideo', {
+      did: agent.did,
+      name: `${crypto.randomUUID()}.mp4`,
+    }),
+    {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${uploadToken}`,
+        'content-type': file.type,
+      },
+      body: file,
+    },
+  );
+  if (!uploadRes.ok) {
+    const message = await uploadRes.text().catch(() => '');
+    throw new Error(
+      `Failed to upload video (${uploadRes.status})${message ? `: ${message}` : ''}`,
+    );
+  }
+  let jobStatus = await uploadRes.json();
+  if (jobStatus.jobStatus) jobStatus = jobStatus.jobStatus;
+  if (jobStatus.error) {
+    throw new Error(jobStatus.message || jobStatus.error);
+  }
+
+  const videoAgent = new BskyAgent({ service: BSKY_VIDEO_SERVICE });
+  const statusToken = await getServiceAuthToken({
+    agent,
+    aud: BSKY_VIDEO_SERVICE_DID,
+    lxm: 'app.bsky.video.getJobStatus',
+  });
+  for (let i = 0; i < 60; i++) {
+    if (jobStatus.state === 'JOB_STATE_COMPLETED' && jobStatus.blob) {
+      return jobStatus.blob;
+    }
+    if (jobStatus.state === 'JOB_STATE_FAILED') {
+      throw new Error(
+        jobStatus.message || jobStatus.error || 'Video upload failed',
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+    const statusRes = await videoAgent.app.bsky.video.getJobStatus(
+      { jobId: jobStatus.jobId },
+      { headers: { authorization: `Bearer ${statusToken}` } },
+    );
+    jobStatus = statusRes.data.jobStatus || statusRes.data;
+  }
+  throw new Error('Timed out waiting for Bluesky video processing');
+}
+
+function escapeHTML(value = '') {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+function textToHTML(text = '') {
+  return escapeHTML(text).replace(/\n/g, '<br />');
+}
+
+function richTextToHTML(text = '', facets = []) {
+  if (!facets?.length) return textToHTML(text);
+  const richText = new RichText({ text, facets });
+  return Array.from(richText.segments())
+    .map((segment) => {
+      const html = textToHTML(segment.text);
+      if (segment.link?.uri) {
+        return `<a href="${escapeHTML(segment.link.uri)}" target="_blank" rel="nofollow noopener noreferrer">${html}</a>`;
+      }
+      if (segment.mention?.did) {
+        return `<a href="https://bsky.app/profile/${escapeHTML(segment.mention.did)}" class="mention" target="_blank" rel="nofollow noopener noreferrer">${html}</a>`;
+      }
+      if (segment.tag?.tag) {
+        return `<a href="/t/${encodeURIComponent(segment.tag.tag)}" class="mention hashtag" rel="tag">#<span>${escapeHTML(segment.tag.tag)}</span></a>`;
+      }
+      return html;
+    })
+    .join('');
+}
+
+function actorToAccount(actor = {}) {
+  const handle = actor.handle || actor.did || 'unknown.bsky.social';
+  const displayName = actor.displayName || handle;
+  const description = actor.description || '';
+  const url = `https://bsky.app/profile/${handle}`;
+  return {
+    id: actor.did || handle,
+    username: handle,
+    acct: handle,
+    displayName,
+    note: textToHTML(description),
+    source: {
+      note: description,
+      fields: [],
+    },
+    url,
+    uri: actor.did,
+    avatar: actor.avatar,
+    avatarStatic: actor.avatar,
+    header: actor.banner,
+    headerStatic: actor.banner,
+    followersCount: actor.followersCount || 0,
+    followingCount: actor.followsCount || 0,
+    statusesCount: actor.postsCount || 0,
+    emojis: [],
+    fields: [],
+    bot: false,
+    group: false,
+  };
+}
+
+function embedToParts(embed, agent) {
+  const mediaAttachments = [];
+  let card;
+  let quote;
+
+  if (!embed) return { mediaAttachments, card, quote };
+  if (Array.isArray(embed)) {
+    embed.forEach((item) => {
+      const parts = embedToParts(item, agent);
+      mediaAttachments.push(...parts.mediaAttachments);
+      card ||= parts.card;
+      quote ||= parts.quote;
+    });
+    return { mediaAttachments, card, quote };
+  }
+
+  const images = embed.images || embed.media?.images || [];
+  images.forEach((image, index) => {
+    const fullsize = image.fullsize || image.thumb;
+    mediaAttachments.push({
+      id: `${fullsize || index}`,
+      type: 'image',
+      url: fullsize,
+      previewUrl: image.thumb || fullsize,
+      remoteUrl: fullsize,
+      description: image.alt || '',
+      meta: {
+        original: {
+          width: image.aspectRatio?.width,
+          height: image.aspectRatio?.height,
+        },
+      },
+    });
+  });
+
+  const external = embed.external || embed.media?.external;
+  if (external) {
+    card = {
+      url: external.uri,
+      title: external.title || external.uri,
+      description: external.description || '',
+      image: external.thumb,
+      type: 'link',
+    };
+  }
+
+  const video = embed.video || embed.media?.video;
+  if (video?.playlist) {
+    mediaAttachments.push({
+      id: video.playlist,
+      type: 'video',
+      url: video.playlist,
+      previewUrl: video.thumbnail,
+      remoteUrl: video.playlist,
+      description: video.alt || '',
+      meta: {
+        original: {
+          width: video.aspectRatio?.width,
+          height: video.aspectRatio?.height,
+        },
+      },
+    });
+  }
+
+  const record = embed.record?.record || embed.record;
+  if (record?.uri && record?.author && record?.value) {
+    quote = {
+      id: encodeAtprotoID(record.uri),
+      state: 'accepted',
+      quotedStatus: postToStatus({ post: record }, agent),
+    };
+  }
+
+  return { mediaAttachments, card, quote };
+}
+
+function postURL(post) {
+  const rkey = post.uri?.split('/').pop();
+  return `https://bsky.app/profile/${post.author?.handle || post.author?.did}/post/${rkey}`;
+}
+
+function parseBskyPostURL(text = '') {
+  const match = String(text).match(
+    /https?:\/\/bsky\.app\/profile\/([^/\s]+)\/post\/([^?\s#]+)/i,
+  );
+  if (!match) return null;
+  return {
+    actor: decodeURIComponent(match[1]),
+    rkey: decodeURIComponent(match[2]),
+  };
+}
+
+function normalizeActor(actor) {
+  if (!actor) return actor;
+  return String(actor)
+    .replace(/^@/, '')
+    .replace(/^https?:\/\/bsky\.app\/profile\//, '')
+    .replace(/\/+$/, '');
+}
+
+function decodeResourceID(id) {
+  return decodeURIComponent(id);
+}
+
+function atprotoRkey(uri) {
+  return uri?.split('/').pop();
+}
+
+async function wait(ms) {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function listToPhanpyList(list = {}) {
+  const uri = list.uri;
+  return {
+    id: encodeURIComponent(uri),
+    title: list.name || list.displayName || uri,
+    repliesPolicy: 'list',
+    exclusive: false,
+    _atproto: {
+      uri,
+      cid: list.cid,
+      purpose: list.purpose,
+      type: 'list',
+    },
+  };
+}
+
+function feedGeneratorToPhanpyList(feed = {}) {
+  const uri = feed.uri;
+  return {
+    id: encodeURIComponent(uri),
+    title: feed.displayName || feed.name || uri,
+    repliesPolicy: 'list',
+    exclusive: false,
+    _atproto: {
+      uri,
+      cid: feed.cid,
+      type: 'feed',
+    },
+  };
+}
+
+export function postToStatus(feedItemOrPost, agent) {
+  const post = feedItemOrPost?.post || feedItemOrPost;
+  const record = post?.record || post?.value || {};
+  const replyRef = post.reply || record.reply;
+  const id = encodeAtprotoID(post.uri);
+  const { mediaAttachments, card, quote } = embedToParts(
+    post.embed || post.embeds || record.embed || record.embeds,
+    agent,
+  );
+  const mentions = (record.facets || []).flatMap((facet) => {
+    const segment = Array.from(
+      new RichText({
+        text: record.text || '',
+        facets: [facet],
+      }).segments(),
+    ).find((segment) => segment.facet);
+    const text = segment?.text;
+    return (facet.features || [])
+      .filter((feature) => feature.$type === 'app.bsky.richtext.facet#mention')
+      .map((feature) => {
+        const username = (text || feature.did).replace(/^@/, '');
+        return {
+          id: feature.did,
+          username,
+          acct: username,
+          url: `https://bsky.app/profile/${feature.did}`,
+        };
+      });
+  });
+  const status = {
+    id,
+    uri: post.uri,
+    url: postURL(post),
+    createdAt: record.createdAt || post.indexedAt,
+    account: actorToAccount(post.author),
+    content: richTextToHTML(record.text || '', record.facets),
+    visibility: 'public',
+    sensitive: !!post.labels?.length,
+    spoilerText: '',
+    language: record.langs?.[0],
+    repliesCount: post.replyCount || 0,
+    reblogsCount: post.repostCount || 0,
+    favouritesCount: post.likeCount || 0,
+    quotesCount: post.quoteCount || 0,
+    reblogged: !!post.viewer?.repost,
+    favourited: !!post.viewer?.like,
+    bookmarked: !!post.viewer?.bookmarked,
+    muted: false,
+    mediaAttachments,
+    card,
+    mentions,
+    tags: (record.facets || [])
+      .flatMap((facet) => facet.features || [])
+      .filter((feature) => feature.$type === 'app.bsky.richtext.facet#tag')
+      .map((feature) => ({
+        name: feature.tag,
+        url: `/t/${encodeURIComponent(feature.tag)}`,
+      })),
+    emojis: [],
+    poll: null,
+    editedAt: null,
+    inReplyToId: replyRef?.parent?.uri
+      ? encodeAtprotoID(replyRef.parent.uri)
+      : null,
+    inReplyToAccountId: post.reply?.parent?.author?.did || null,
+    quote,
+    _atproto: {
+      uri: post.uri,
+      cid: post.cid,
+      root: replyRef?.root,
+      parent: replyRef?.parent,
+      like: post.viewer?.like,
+      repost: post.viewer?.repost,
+      text: record.text || '',
+    },
+    quoteApproval: {
+      currentUser: 'automatic',
+      automatic: ['public'],
+      manual: [],
+    },
+  };
+
+  if (feedItemOrPost?.reason?.$type === 'app.bsky.feed.defs#reasonRepost') {
+    return {
+      ...status,
+      id: `${id}-repost-${feedItemOrPost.reason.indexedAt}`,
+      createdAt: feedItemOrPost.reason.indexedAt,
+      account: actorToAccount(feedItemOrPost.reason.by),
+      reblog: status,
+    };
+  }
+
+  return status;
+}
+
+function createIterator(fetchPage) {
+  let cursor;
+  return {
+    async next() {
+      const res = await fetchPage(cursor);
+      cursor = res.cursor;
+      return {
+        value: res.items,
+        done: !res.cursor,
+      };
+    },
+  };
+}
+
+function makeCollection(fetchPage) {
+  return {
+    values() {
+      return createIterator(fetchPage);
+    },
+  };
+}
+
+function emptyCollection() {
+  return makeCollection(async () => ({ cursor: undefined, items: [] }));
+}
+
+function relationshipFor(id) {
+  return {
+    id,
+    following: false,
+    showingReblogs: true,
+    notifying: false,
+    followedBy: false,
+    blocking: false,
+    blockedBy: false,
+    muting: false,
+    mutingNotifications: false,
+    requested: false,
+    domainBlocking: false,
+    endorsed: false,
+  };
+}
+
+function relationshipFromAtproto(rel = {}, profile = {}) {
+  return {
+    ...relationshipFor(rel.did || profile.did),
+    id: rel.did || profile.did,
+    following: !!rel.following,
+    followedBy: !!rel.followedBy,
+    blocking: !!rel.blocking,
+    blockedBy: !!rel.blockedBy,
+    muting: !!profile.viewer?.muted,
+    _atproto: {
+      following: rel.following,
+      blocking: rel.blocking,
+    },
+  };
+}
+
+function notificationType(reason) {
+  switch (reason) {
+    case 'like':
+    case 'like-via-repost':
+      return 'favourite';
+    case 'repost':
+      return 'reblog';
+    case 'quote':
+      return 'quote';
+    case 'reply':
+    case 'mention':
+      return 'mention';
+    case 'follow':
+      return 'follow';
+    default:
+      return 'status';
+  }
+}
+
+function notificationStatusURI(notification) {
+  if (notification.reason === 'like-via-repost') {
+    return notification.record?.subject?.uri || notification.reasonSubject;
+  }
+  if (['like', 'repost'].includes(notification.reason)) {
+    return notification.reasonSubject || notification.record?.subject?.uri;
+  }
+  if (['quote', 'reply', 'mention'].includes(notification.reason)) {
+    return notification.uri || notification.reasonSubject;
+  }
+  return (
+    notification.reasonSubject ||
+    notification.record?.subject?.uri ||
+    notification.uri
+  );
+}
+
+function toGroupedNotificationsPage({ cursor, items }) {
+  const accounts = [];
+  const statuses = [];
+  const accountIds = new Set();
+  const statusIds = new Set();
+  const notificationGroups = items.map((notification) => {
+    const accountId = notification.account?.id;
+    const statusId = notification.status?.id;
+    if (notification.account && accountId && !accountIds.has(accountId)) {
+      accountIds.add(accountId);
+      accounts.push(notification.account);
+    }
+    if (notification.status && statusId && !statusIds.has(statusId)) {
+      statusIds.add(statusId);
+      statuses.push(notification.status);
+    }
+    return {
+      ...notification,
+      groupKey: `${notification.type}:${statusId || ''}:${accountId || ''}:${notification.id}`,
+      sampleAccountIds: accountId ? [accountId] : [],
+      statusId,
+      notificationsCount: 1,
+      mostRecentNotificationId: notification.id,
+      latestPageNotificationAt: notification.createdAt,
+    };
+  });
+  return {
+    cursor,
+    items: {
+      accounts,
+      statuses,
+      notificationGroups,
+    },
+  };
+}
+
+async function createMediaUpload({ agent, uploadedMedia, file, description }) {
+  if (!file) throw new Error('Missing media file');
+  const url = URL.createObjectURL(file);
+
+  if (file.type?.startsWith('image/')) {
+    const res = await agent.uploadBlob(file, {
+      encoding: file.type,
+    });
+    const id = String(
+      res.data.blob?.ref?.toString?.() ||
+        res.data.blob?.ref?.$link ||
+        crypto.randomUUID(),
+    );
+    const media = {
+      id,
+      type: 'image',
+      url,
+      previewUrl: url,
+      description,
+      blob: res.data.blob,
+    };
+    uploadedMedia.set(id, media);
+    return media;
+  }
+
+  if (file.type?.startsWith('video/')) {
+    const blob = await uploadVideoBlob(agent, file);
+    const id = String(
+      blob?.ref?.toString?.() || blob?.ref?.$link || crypto.randomUUID(),
+    );
+    const media = {
+      id,
+      type: 'video',
+      url,
+      previewUrl: url,
+      description,
+      blob,
+    };
+    uploadedMedia.set(id, media);
+    return media;
+  }
+
+  throw new Error(
+    'Only image and MP4 video uploads are supported for Bluesky posts',
+  );
+}
+
+function hasUploadableFile(file) {
+  return file instanceof Blob && file.size > 0;
+}
+
+async function uploadProfileImage(agent, file) {
+  if (!hasUploadableFile(file)) return null;
+  if (!file.type?.startsWith('image/')) {
+    throw new Error('Only images are supported for Bluesky profile media');
+  }
+  const res = await agent.uploadBlob(file, {
+    encoding: file.type,
+  });
+  return res.data.blob;
+}
+
+export function createAtprotoClient({
+  session,
+  service = BSKY_PDS,
+  persistSession,
+}) {
+  const agent = new BskyAgent({ service, persistSession });
+  if (session) {
+    agent.sessionManager.session = session;
+  }
+  const uploadedMedia = new Map();
+
+  const statusAPI = (id) => {
+    const uri = decodeURIComponent(id);
+    const hydrateLegacyLinkQuote = async (status) => {
+      if (status.quote) return status;
+      const parsed = parseBskyPostURL(status._atproto?.text || '');
+      if (!parsed) return status;
+      const profile = await agent.getProfile({ actor: parsed.actor });
+      const quoteURI = `at://${profile.data.did}/app.bsky.feed.post/${parsed.rkey}`;
+      const quoteRes = await agent.getPosts({ uris: [quoteURI] });
+      const quotePost = quoteRes.data.posts?.[0];
+      if (!quotePost) return status;
+      return {
+        ...status,
+        quote: {
+          id: encodeAtprotoID(quotePost.uri),
+          state: 'accepted',
+          quotedStatus: postToStatus(quotePost, agent),
+        },
+      };
+    };
+    return {
+      async fetch() {
+        const res = await agent.getPosts({ uris: [uri] });
+        const post = res.data.posts?.[0];
+        if (!post) throw new Error('Post not found');
+        return hydrateLegacyLinkQuote(postToStatus(post, agent));
+      },
+      context: {
+        async fetch() {
+          const res = await agent.getPostThread({
+            uri,
+            depth: 8,
+            parentHeight: 8,
+          });
+          const flatten = (node, bucket = []) => {
+            if (node?.post) bucket.push(postToStatus(node.post, agent));
+            node?.replies?.forEach((reply) => flatten(reply, bucket));
+            return bucket;
+          };
+          const ancestors = [];
+          let parent = res.data.thread?.parent;
+          while (parent?.post) {
+            ancestors.unshift(postToStatus(parent.post, agent));
+            parent = parent.parent;
+          }
+          const descendants = res.data.thread?.replies?.flatMap((reply) =>
+            flatten(reply, []),
+          );
+          return { ancestors, descendants: descendants || [] };
+        },
+      },
+      source: {
+        async fetch() {
+          const current = await statusAPI(id).fetch();
+          return {
+            id: current.id,
+            text: current.content
+              .replace(/<br\s*\/?>/gi, '\n')
+              .replace(/<[^>]+>/g, ''),
+            spoilerText: current.spoilerText || '',
+          };
+        },
+      },
+      history: {
+        async list() {
+          const current = await statusAPI(id).fetch();
+          return [
+            {
+              id: current.id,
+              createdAt: current.createdAt,
+              account: current.account,
+              content: current.content,
+              spoilerText: current.spoilerText,
+              mediaAttachments: current.mediaAttachments,
+              emojis: current.emojis,
+              poll: current.poll,
+            },
+          ];
+        },
+      },
+      rebloggedBy: {
+        list({ limit = 80 } = {}) {
+          return makeCollection(async (cursor) => {
+            const res = await agent.app.bsky.feed.getRepostedBy({
+              uri,
+              limit,
+              cursor,
+            });
+            return {
+              cursor: res.data.cursor,
+              items: res.data.repostedBy.map(actorToAccount),
+            };
+          });
+        },
+      },
+      favouritedBy: {
+        list({ limit = 80 } = {}) {
+          return makeCollection(async (cursor) => {
+            const res = await agent.app.bsky.feed.getLikes({
+              uri,
+              limit,
+              cursor,
+            });
+            return {
+              cursor: res.data.cursor,
+              items: res.data.likes.map((like) => actorToAccount(like.actor)),
+            };
+          });
+        },
+      },
+      quotes: {
+        list({ limit = 20 } = {}) {
+          return makeCollection(async (cursor) => {
+            const res = await agent.app.bsky.feed.getQuotes({
+              uri,
+              limit,
+              cursor,
+            });
+            return {
+              cursor: res.data.cursor,
+              items: res.data.posts.map((post) => postToStatus(post, agent)),
+            };
+          });
+        },
+        $select() {
+          return {
+            revoke: {
+              async create() {
+                throw new Error('Bluesky quote removal is not supported');
+              },
+            },
+          };
+        },
+      },
+      interactionPolicy: {
+        async update() {
+          throw new Error('Bluesky quote settings are not supported');
+        },
+      },
+      async favourite() {
+        const current = await this.fetch();
+        const like = await agent.like(current.uri, current._atproto.cid);
+        return {
+          ...current,
+          favourited: true,
+          _atproto: { ...current._atproto, like: like.uri },
+        };
+      },
+      async unfavourite() {
+        const current = await this.fetch();
+        if (current._atproto.like)
+          await agent.deleteLike(current._atproto.like);
+        return { ...current, favourited: false };
+      },
+      async reblog() {
+        const current = await this.fetch();
+        const repost = await agent.repost(current.uri, current._atproto.cid);
+        return {
+          ...current,
+          reblogged: true,
+          _atproto: { ...current._atproto, repost: repost.uri },
+        };
+      },
+      async unreblog() {
+        const current = await this.fetch();
+        if (current._atproto.repost)
+          await agent.deleteRepost(current._atproto.repost);
+        return { ...current, reblogged: false };
+      },
+      async bookmark() {
+        const current = await this.fetch();
+        await agent.app.bsky.bookmark.createBookmark({
+          uri,
+          cid: current._atproto.cid,
+        });
+        return { ...current, bookmarked: true };
+      },
+      async unbookmark() {
+        const current = await this.fetch();
+        await agent.app.bsky.bookmark.deleteBookmark({ uri });
+        return { ...current, bookmarked: false };
+      },
+      async remove() {
+        await agent.app.bsky.feed.post.delete({
+          repo: agent.did,
+          rkey: atprotoRkey(uri),
+        });
+        return {};
+      },
+      async update() {
+        throw new Error('Bluesky posts cannot be edited');
+      },
+      async mute() {
+        const current = await this.fetch();
+        return { ...current, muted: true };
+      },
+      async unmute() {
+        const current = await this.fetch();
+        return { ...current, muted: false };
+      },
+      async pin() {
+        throw new Error('Bluesky pinned posts are not supported');
+      },
+      async unpin() {
+        throw new Error('Bluesky pinned posts are not supported');
+      },
+    };
+  };
+
+  async function fetchRelationship(id) {
+    const actor = normalizeActor(id);
+    const profileRes = await agent.getProfile({ actor });
+    const relationshipsRes = await agent.app.bsky.graph.getRelationships({
+      actor: agent.did,
+      others: [profileRes.data.did],
+    });
+    return relationshipFromAtproto(
+      relationshipsRes.data.relationships?.[0],
+      profileRes.data,
+    );
+  }
+
+  const accountAPI = (id) => ({
+    async fetch() {
+      const res = await agent.getProfile({ actor: normalizeActor(id) });
+      return actorToAccount(res.data);
+    },
+    statuses: {
+      list({
+        limit = 20,
+        exclude_replies: excludeReplies,
+        exclude_reblogs: excludeReposts,
+        only_media: onlyMedia,
+        tagged,
+        pinned,
+      } = {}) {
+        if (pinned) return emptyCollection();
+        return makeCollection(async (cursor) => {
+          const res = await agent.getAuthorFeed({
+            actor: normalizeActor(id),
+            limit,
+            cursor,
+            filter: 'posts_with_replies',
+          });
+          let items = res.data.feed.map((item) => postToStatus(item, agent));
+          if (excludeReplies) items = items.filter((item) => !item.inReplyToId);
+          if (excludeReposts) items = items.filter((item) => !item.reblog);
+          if (onlyMedia) {
+            items = items.filter((item) => item.mediaAttachments?.length);
+          }
+          if (tagged) {
+            const tag = tagged.toLowerCase();
+            items = items.filter((item) =>
+              item.tags?.some((itemTag) => itemTag.name?.toLowerCase() === tag),
+            );
+          }
+          return { cursor: res.data.cursor, items };
+        });
+      },
+    },
+    followers: {
+      list({ limit = 80 } = {}) {
+        return makeCollection(async (cursor) => {
+          const res = await agent.getFollowers({
+            actor: normalizeActor(id),
+            limit,
+            cursor,
+          });
+          return {
+            cursor: res.data.cursor,
+            items: res.data.followers.map(actorToAccount),
+          };
+        });
+      },
+    },
+    following: {
+      list({ limit = 80 } = {}) {
+        return makeCollection(async (cursor) => {
+          const res = await agent.getFollows({
+            actor: normalizeActor(id),
+            limit,
+            cursor,
+          });
+          return {
+            cursor: res.data.cursor,
+            items: res.data.follows.map(actorToAccount),
+          };
+        });
+      },
+    },
+    featuredTags: {
+      async list() {
+        return [];
+      },
+    },
+    endorsements: {
+      async list() {
+        return [];
+      },
+    },
+    note: {
+      async create() {
+        throw new Error('Bluesky private notes are not supported');
+      },
+    },
+    async follow() {
+      const current = await fetchRelationship(id);
+      if (!current.following) {
+        const follow = await agent.follow(current.id);
+        return {
+          ...current,
+          following: true,
+          _atproto: { ...current._atproto, following: follow.uri },
+        };
+      }
+      return current;
+    },
+    async unfollow() {
+      const current = await fetchRelationship(id);
+      if (current._atproto?.following) {
+        await agent.deleteFollow(current._atproto.following);
+      }
+      return {
+        ...current,
+        following: false,
+        _atproto: { ...current._atproto, following: undefined },
+      };
+    },
+    async mute() {
+      const actor = normalizeActor(id);
+      await agent.mute(actor);
+      const current = await fetchRelationship(actor);
+      return { ...current, muting: true };
+    },
+    async unmute() {
+      const actor = normalizeActor(id);
+      await agent.unmute(actor);
+      const current = await fetchRelationship(actor);
+      return { ...current, muting: false };
+    },
+    async block() {
+      const current = await fetchRelationship(id);
+      if (!current.blocking) {
+        const block = await agent.app.bsky.graph.block.create(
+          { repo: agent.did },
+          { subject: current.id, createdAt: new Date().toISOString() },
+        );
+        return {
+          ...current,
+          blocking: true,
+          _atproto: { ...current._atproto, blocking: block.uri },
+        };
+      }
+      return current;
+    },
+    async unblock() {
+      const current = await fetchRelationship(id);
+      if (current._atproto?.blocking) {
+        await agent.app.bsky.graph.block.delete({
+          repo: agent.did,
+          rkey: atprotoRkey(current._atproto.blocking),
+        });
+      }
+      return {
+        ...current,
+        blocking: false,
+        _atproto: { ...current._atproto, blocking: undefined },
+      };
+    },
+    async pin() {
+      throw new Error('Bluesky featured profiles are not supported');
+    },
+    async unpin() {
+      throw new Error('Bluesky featured profiles are not supported');
+    },
+  });
+
+  const listAPI = (id) => {
+    const uri = decodeResourceID(id);
+    return {
+      async fetch() {
+        if (uri.includes('/app.bsky.feed.generator/')) {
+          const res = await agent.app.bsky.feed.getFeedGenerator({
+            feed: uri,
+          });
+          return feedGeneratorToPhanpyList(res.data.view);
+        }
+        const res = await agent.app.bsky.graph.getList({
+          list: uri,
+          limit: 1,
+        });
+        return listToPhanpyList(res.data.list);
+      },
+      async update({ title } = {}) {
+        if (uri.includes('/app.bsky.feed.generator/')) {
+          throw new Error('Feed generators are not editable here');
+        }
+        const current = await this.fetch();
+        await agent.com.atproto.repo.putRecord({
+          repo: agent.did,
+          collection: 'app.bsky.graph.list',
+          rkey: atprotoRkey(uri),
+          record: {
+            purpose:
+              current._atproto?.purpose || 'app.bsky.graph.defs#curatelist',
+            name: title || current.title,
+            description: '',
+            createdAt: new Date().toISOString(),
+          },
+        });
+        return { ...current, title: title || current.title };
+      },
+      async remove() {
+        if (uri.includes('/app.bsky.feed.generator/')) {
+          throw new Error('Feed generators are not removable here');
+        }
+        const listitemURIs = [];
+        let cursor;
+        do {
+          const res = await agent.app.bsky.graph.listitem.list({
+            repo: agent.did,
+            cursor,
+            limit: 100,
+          });
+          listitemURIs.push(
+            ...res.records
+              .filter((record) => record.value?.list === uri)
+              .map((record) => record.uri),
+          );
+          cursor = res.cursor;
+        } while (cursor);
+
+        const deleteWrite = (recordURI) => ({
+          $type: 'com.atproto.repo.applyWrites#delete',
+          collection: recordURI.split('/').slice(-2, -1)[0],
+          rkey: atprotoRkey(recordURI),
+        });
+        const writes = [...listitemURIs.map(deleteWrite), deleteWrite(uri)];
+        for (let i = 0; i < writes.length; i += 10) {
+          await agent.com.atproto.repo.applyWrites({
+            repo: agent.did,
+            writes: writes.slice(i, i + 10),
+          });
+        }
+        return {};
+      },
+      accounts: {
+        list({ limit = 80 } = {}) {
+          return makeCollection(async (cursor) => {
+            const res = await agent.app.bsky.graph.getList({
+              list: uri,
+              limit,
+              cursor,
+            });
+            return {
+              cursor: res.data.cursor,
+              items: res.data.items.map((item) => actorToAccount(item.subject)),
+            };
+          });
+        },
+        async create({ accountIds = [] } = {}) {
+          if (uri.includes('/app.bsky.feed.generator/')) {
+            throw new Error('Feed generators do not have editable members');
+          }
+          await Promise.all(
+            accountIds.map((accountID) =>
+              agent.app.bsky.graph.listitem.create(
+                { repo: agent.did },
+                {
+                  subject: accountID,
+                  list: uri,
+                  createdAt: new Date().toISOString(),
+                },
+              ),
+            ),
+          );
+          return {};
+        },
+        async remove({ accountIds = [] } = {}) {
+          if (uri.includes('/app.bsky.feed.generator/')) {
+            throw new Error('Feed generators do not have editable members');
+          }
+          const ids = new Set(accountIds);
+          const removals = [];
+          let cursor;
+          do {
+            const res = await agent.app.bsky.graph.listitem.list({
+              repo: agent.did,
+              cursor,
+              limit: 100,
+            });
+            removals.push(
+              ...res.records.filter(
+                (record) =>
+                  record.value?.list === uri && ids.has(record.value?.subject),
+              ),
+            );
+            cursor = res.cursor;
+          } while (cursor);
+          await Promise.all(
+            removals.map((record) =>
+              agent.app.bsky.graph.listitem.delete({
+                repo: agent.did,
+                rkey: atprotoRkey(record.uri),
+              }),
+            ),
+          );
+          return {};
+        },
+      },
+    };
+  };
+
+  async function fetchNotifications(
+    { limit = 80, types, excludeTypes } = {},
+    cursor,
+  ) {
+    const res = await agent.listNotifications({
+      limit,
+      cursor,
+    });
+    const allowedTypes = types?.length ? new Set(types) : null;
+    const blockedTypes = excludeTypes?.length ? new Set(excludeTypes) : null;
+    const notifications = res.data.notifications.filter((notification) => {
+      const type = notificationType(notification.reason);
+      if (allowedTypes && !allowedTypes.has(type)) return false;
+      if (blockedTypes?.has(type)) return false;
+      return true;
+    });
+    const statusURIs = [
+      ...new Set(
+        notifications
+          .map((notification) => notificationStatusURI(notification))
+          .filter(Boolean),
+      ),
+    ];
+    const posts = statusURIs.length
+      ? await agent
+          .getPosts({ uris: statusURIs })
+          .then((res) => res.data.posts)
+          .catch(() => [])
+      : [];
+    const postMap = Object.fromEntries(
+      posts.map((post) => [post.uri, postToStatus(post, agent)]),
+    );
+    const items = notifications.map((notification) => {
+      const statusURI = notificationStatusURI(notification);
+      return {
+        id: `${notification.uri}-${notification.indexedAt}`,
+        type: notificationType(notification.reason),
+        createdAt: notification.indexedAt,
+        account: actorToAccount(notification.author),
+        status: postMap[statusURI],
+      };
+    });
+    const statusRequiredTypes = new Set([
+      'favourite',
+      'reblog',
+      'status',
+      'mention',
+      'quote',
+    ]);
+    return {
+      cursor: res.data.cursor,
+      items: items.filter(
+        (item) => !statusRequiredTypes.has(item.type) || item.status,
+      ),
+    };
+  }
+
+  return {
+    agent,
+    v1: {
+      accounts: {
+        async verifyCredentials() {
+          const profile = await agent.getProfile({ actor: agent.did });
+          return actorToAccount(profile.data);
+        },
+        async updateCredentials({
+          avatar,
+          header,
+          displayName,
+          note,
+          source,
+        } = {}) {
+          if (source) return this.verifyCredentials();
+          const current = await agent.com.atproto.repo
+            .getRecord({
+              repo: agent.did,
+              collection: 'app.bsky.actor.profile',
+              rkey: 'self',
+            })
+            .then((res) => res.data.value)
+            .catch(() => ({
+              $type: 'app.bsky.actor.profile',
+            }));
+          const next = {
+            ...current,
+          };
+          if (displayName !== undefined) {
+            next.displayName = displayName || '';
+          }
+          if (note !== undefined) {
+            next.description = note || '';
+          }
+          const avatarBlob = await uploadProfileImage(agent, avatar);
+          if (avatarBlob) next.avatar = avatarBlob;
+          const headerBlob = await uploadProfileImage(agent, header);
+          if (headerBlob) next.banner = headerBlob;
+          await agent.com.atproto.repo.putRecord({
+            repo: agent.did,
+            collection: 'app.bsky.actor.profile',
+            rkey: 'self',
+            record: next,
+          });
+          return this.verifyCredentials();
+        },
+        async lookup({ acct }) {
+          const profile = await agent.getProfile({
+            actor: normalizeActor(acct),
+          });
+          return actorToAccount(profile.data);
+        },
+        $select: accountAPI,
+        relationships: {
+          async fetch({ id } = {}) {
+            const ids = Array.isArray(id) ? id : [id].filter(Boolean);
+            if (!ids.length) return [];
+            const profilesRes = await agent.getProfiles({
+              actors: ids.map(normalizeActor),
+            });
+            const relationshipsRes =
+              await agent.app.bsky.graph.getRelationships({
+                actor: agent.did,
+                others: ids.map(normalizeActor),
+              });
+            const profiles = Object.fromEntries(
+              profilesRes.data.profiles.map((profile) => [
+                profile.did,
+                profile,
+              ]),
+            );
+            return relationshipsRes.data.relationships.map((relationship) =>
+              relationshipFromAtproto(relationship, profiles[relationship.did]),
+            );
+          },
+        },
+        familiarFollowers: {
+          async fetch({ id } = {}) {
+            const ids = Array.isArray(id) ? id : [id].filter(Boolean);
+            return ids.map((accountID) => ({ id: accountID, accounts: [] }));
+          },
+        },
+        search: {
+          list({ q, limit = 10 } = {}) {
+            return makeCollection(async () => {
+              const res = await agent.searchActors({
+                term: q || '',
+                limit,
+              });
+              return {
+                cursor: undefined,
+                items: res.data.actors.map(actorToAccount),
+              };
+            });
+          },
+        },
+      },
+      timelines: {
+        home: {
+          list({ limit = 20 } = {}) {
+            return makeCollection(async (cursor) => {
+              const res = await agent.getTimeline({ limit, cursor });
+              return {
+                cursor: res.data.cursor,
+                items: res.data.feed.map((item) => postToStatus(item, agent)),
+              };
+            });
+          },
+        },
+        public: {
+          list({ limit = 20 } = {}) {
+            return makeCollection(async (cursor) => {
+              const res = await agent.app.bsky.feed.getFeed({
+                feed: BSKY_DISCOVER_FEED,
+                limit,
+                cursor,
+              });
+              return {
+                cursor: res.data.cursor,
+                items: res.data.feed.map((item) => postToStatus(item, agent)),
+              };
+            });
+          },
+        },
+        tag: {
+          $select(tag) {
+            return {
+              list({ limit = 20, any = [], onlyMedia } = {}) {
+                const q = [tag, ...any]
+                  .filter(Boolean)
+                  .map((value) => `#${String(value).replace(/^#/, '')}`)
+                  .join(' ');
+                return makeCollection(async (cursor) => {
+                  const res = await agent.app.bsky.feed.searchPosts({
+                    q,
+                    limit,
+                    cursor,
+                  });
+                  let items = res.data.posts.map((post) =>
+                    postToStatus(post, agent),
+                  );
+                  if (onlyMedia) {
+                    items = items.filter(
+                      (item) => item.mediaAttachments?.length,
+                    );
+                  }
+                  return { cursor: res.data.cursor, items };
+                });
+              },
+            };
+          },
+        },
+        link: {
+          list({ url, limit = 20 } = {}) {
+            if (!url) return emptyCollection();
+            return makeCollection(async (cursor) => {
+              const res = await agent.app.bsky.feed.searchPosts({
+                q: url,
+                limit,
+                cursor,
+              });
+              return {
+                cursor: res.data.cursor,
+                items: res.data.posts.map((post) => postToStatus(post, agent)),
+              };
+            });
+          },
+        },
+        list: {
+          $select(id) {
+            const uri = decodeResourceID(id);
+            return {
+              list({ limit = 20 } = {}) {
+                return makeCollection(async (cursor) => {
+                  const method = uri.includes('/app.bsky.feed.generator/')
+                    ? 'getFeed'
+                    : 'getListFeed';
+                  const key = method === 'getFeed' ? 'feed' : 'list';
+                  const res = await agent.app.bsky.feed[method]({
+                    [key]: uri,
+                    limit,
+                    cursor,
+                  });
+                  return {
+                    cursor: res.data.cursor,
+                    items: res.data.feed.map((item) =>
+                      postToStatus(item, agent),
+                    ),
+                  };
+                });
+              },
+            };
+          },
+        },
+      },
+      lists: {
+        async list() {
+          const lists = [];
+          let cursor;
+          do {
+            const res = await agent.app.bsky.graph.getLists({
+              actor: agent.did,
+              limit: 50,
+              cursor,
+            });
+            lists.push(
+              ...res.data.lists
+                .filter(
+                  (list) => list.purpose === 'app.bsky.graph.defs#curatelist',
+                )
+                .map(listToPhanpyList),
+            );
+            cursor = res.data.cursor;
+          } while (cursor);
+          const preferences = await agent.getPreferences().catch(() => null);
+          const savedFeeds = preferences?.savedFeeds || [];
+          const savedFeedURIs = [
+            BSKY_DISCOVER_FEED,
+            ...savedFeeds
+              .filter((feed) => feed.type === 'feed')
+              .map((feed) => feed.value),
+          ];
+          const feedViews = savedFeedURIs.length
+            ? await agent.app.bsky.feed
+                .getFeedGenerators({
+                  feeds: [...new Set(savedFeedURIs)],
+                })
+                .then((res) => res.data.feeds)
+                .catch(() => [])
+            : [];
+          const actorFeeds = await agent.app.bsky.feed
+            .getActorFeeds({
+              actor: agent.did,
+              limit: 100,
+            })
+            .then((res) => res.data.feeds)
+            .catch(() => []);
+          const savedLists = await Promise.all(
+            savedFeeds
+              .filter((feed) => feed.type === 'list')
+              .map((feed) =>
+                agent.app.bsky.graph
+                  .getList({ list: feed.value, limit: 1 })
+                  .then((res) => listToPhanpyList(res.data.list))
+                  .catch(() => null),
+              ),
+          );
+          const allLists = [
+            ...lists,
+            ...feedViews.map(feedGeneratorToPhanpyList),
+            ...actorFeeds.map(feedGeneratorToPhanpyList),
+            ...savedLists.filter(Boolean),
+          ];
+          return [...new Map(allLists.map((list) => [list.id, list])).values()];
+        },
+        $select: listAPI,
+        async create({ title } = {}) {
+          const res = await agent.app.bsky.graph.list.create(
+            { repo: agent.did },
+            {
+              purpose: 'app.bsky.graph.defs#curatelist',
+              name: title || 'List',
+              description: '',
+              createdAt: new Date().toISOString(),
+            },
+          );
+          return listAPI(encodeURIComponent(res.uri)).fetch();
+        },
+      },
+      bookmarks: {
+        list({ limit = 20 } = {}) {
+          return makeCollection(async (cursor) => {
+            const res = await agent.app.bsky.bookmark.getBookmarks({
+              limit,
+              cursor,
+            });
+            return {
+              cursor: res.data.cursor,
+              items: res.data.bookmarks.map((post) =>
+                postToStatus(post, agent),
+              ),
+            };
+          });
+        },
+      },
+      favourites: {
+        list({ limit = 20 } = {}) {
+          return makeCollection(async (cursor) => {
+            const res = await agent.app.bsky.feed.getActorLikes({
+              actor: agent.did,
+              limit,
+              cursor,
+            });
+            return {
+              cursor: res.data.cursor,
+              items: res.data.feed.map((item) => postToStatus(item, agent)),
+            };
+          });
+        },
+      },
+      mutes: {
+        list({ limit = 80 } = {}) {
+          return makeCollection(async (cursor) => {
+            const res = await agent.app.bsky.graph.getMutes({
+              limit,
+              cursor,
+            });
+            return {
+              cursor: res.data.cursor,
+              items: res.data.mutes.map(actorToAccount),
+            };
+          });
+        },
+      },
+      blocks: {
+        list({ limit = 80 } = {}) {
+          return makeCollection(async (cursor) => {
+            const res = await agent.app.bsky.graph.getBlocks({
+              limit,
+              cursor,
+            });
+            return {
+              cursor: res.data.cursor,
+              items: res.data.blocks.map(actorToAccount),
+            };
+          });
+        },
+      },
+      tags: {
+        $select(name) {
+          return {
+            async fetch() {
+              return {
+                name,
+                url: `/t/${encodeURIComponent(name)}`,
+                history: [],
+                following: false,
+              };
+            },
+            async follow() {
+              throw new Error('Bluesky hashtag follows are not supported');
+            },
+            async unfollow() {
+              throw new Error('Bluesky hashtag follows are not supported');
+            },
+          };
+        },
+      },
+      followedTags: {
+        list() {
+          return emptyCollection();
+        },
+      },
+      featuredTags: {
+        async list() {
+          return [];
+        },
+        async create() {
+          throw new Error('Bluesky featured hashtags are not supported');
+        },
+        $select() {
+          return {
+            async remove() {
+              throw new Error('Bluesky featured hashtags are not supported');
+            },
+          };
+        },
+      },
+      trends: {
+        tags: {
+          list() {
+            return emptyCollection();
+          },
+        },
+        links: {
+          list() {
+            return emptyCollection();
+          },
+        },
+        statuses: {
+          list({ limit = 20 } = {}) {
+            return makeCollection(async (cursor) => {
+              const res = await agent.app.bsky.feed.getFeed({
+                feed: BSKY_DISCOVER_FEED,
+                limit,
+                cursor,
+              });
+              return {
+                cursor: res.data.cursor,
+                items: res.data.feed.map((item) => postToStatus(item, agent)),
+              };
+            });
+          },
+        },
+      },
+      notifications: {
+        list(opts = {}) {
+          return makeCollection((cursor) => fetchNotifications(opts, cursor));
+        },
+        $select(id) {
+          return {
+            async fetch() {
+              let cursor;
+              for (let page = 0; page < 5; page++) {
+                const res = await fetchNotifications({ limit: 80 }, cursor);
+                const notification = res.items.find((item) => item.id === id);
+                if (notification) return notification;
+                if (!res.cursor) break;
+                cursor = res.cursor;
+              }
+              throw new Error('Notification not found');
+            },
+          };
+        },
+        requests: {
+          async list() {
+            return [];
+          },
+          $select(id) {
+            return {
+              async accept() {
+                return { id };
+              },
+              async dismiss() {
+                return { id };
+              },
+            };
+          },
+        },
+      },
+      conversations: {
+        list() {
+          return emptyCollection();
+        },
+        $select() {
+          return {
+            async read() {
+              return {};
+            },
+          };
+        },
+      },
+      announcements: {
+        async list() {
+          return [];
+        },
+      },
+      push: {
+        subscription: {
+          async fetch() {
+            throw new Error('Push subscription not found');
+          },
+          async create() {
+            throw new Error('Bluesky push subscriptions are not supported');
+          },
+          async update() {
+            throw new Error('Bluesky push subscriptions are not supported');
+          },
+          async remove() {
+            return {};
+          },
+        },
+      },
+      markers: {
+        async create() {
+          return {};
+        },
+        async fetch() {
+          return {};
+        },
+      },
+      customEmojis: {
+        async list() {
+          return [];
+        },
+      },
+      followRequests: {
+        async list() {
+          return [];
+        },
+        $select(id) {
+          return {
+            async authorize() {
+              return relationshipFor(id);
+            },
+            async reject() {
+              return relationshipFor(id);
+            },
+          };
+        },
+      },
+      scheduledStatuses: {
+        list() {
+          return emptyCollection();
+        },
+        $select() {
+          return {
+            async update() {
+              throw new Error('Bluesky scheduled posts are not supported');
+            },
+            async remove() {
+              throw new Error('Bluesky scheduled posts are not supported');
+            },
+          };
+        },
+      },
+      statuses: {
+        $select: statusAPI,
+        async list({ id } = {}) {
+          const ids = Array.isArray(id) ? id : [id].filter(Boolean);
+          if (!ids.length) return [];
+          const uris = ids.map((value) => decodeURIComponent(value));
+          const res = await agent.getPosts({ uris });
+          return res.data.posts.map((post) => postToStatus(post, agent));
+        },
+        async create(params = {}) {
+          if (params.scheduled_at || params.scheduledAt) {
+            throw new Error('Bluesky scheduled posts are not supported');
+          }
+          if (params.poll) {
+            throw new Error('Bluesky polls are not supported');
+          }
+          const inReplyToId = params.in_reply_to_id || params.inReplyToId;
+          const quoteId =
+            params.quoted_status_id || params.quote_id || params.quoteId;
+          const rt = new RichText({ text: params.status || '' });
+          await rt.detectFacets(agent);
+          const record = {
+            text: rt.text,
+            facets: rt.facets,
+            createdAt: new Date().toISOString(),
+          };
+          if (inReplyToId) {
+            const parent = await statusAPI(inReplyToId).fetch();
+            const root = parent._atproto?.root || {
+              uri: parent.uri,
+              cid: parent._atproto.cid,
+            };
+            record.reply = {
+              root,
+              parent: { uri: parent.uri, cid: parent._atproto.cid },
+            };
+          }
+          if (quoteId) {
+            const quote = await statusAPI(quoteId).fetch();
+            record.embed = {
+              $type: 'app.bsky.embed.record',
+              record: { uri: quote.uri, cid: quote._atproto.cid },
+            };
+          }
+          const mediaIds = params.media_ids || params.mediaIds || [];
+          if (mediaIds.length) {
+            const media = mediaIds
+              .map((id) => uploadedMedia.get(id))
+              .filter((media) => media?.blob);
+            const videos = media.filter((media) => media.type === 'video');
+            const images = media
+              .filter((media) => media.type === 'image')
+              .map((media) => ({
+                image: media.blob,
+                alt: media.description || '',
+              }));
+            if (videos.length && images.length) {
+              throw new Error('Bluesky posts cannot mix images and video');
+            }
+            if (videos.length > 1) {
+              throw new Error('Bluesky posts support one video');
+            }
+            if (videos.length) {
+              const videoEmbed = {
+                $type: 'app.bsky.embed.video',
+                video: videos[0].blob,
+                alt: videos[0].description || '',
+              };
+              if (record.embed) {
+                record.embed = {
+                  $type: 'app.bsky.embed.recordWithMedia',
+                  record: record.embed,
+                  media: videoEmbed,
+                };
+              } else {
+                record.embed = videoEmbed;
+              }
+            } else if (images.length) {
+              if (record.embed) {
+                record.embed = {
+                  $type: 'app.bsky.embed.recordWithMedia',
+                  record: record.embed,
+                  media: {
+                    $type: 'app.bsky.embed.images',
+                    images,
+                  },
+                };
+              } else {
+                record.embed = {
+                  $type: 'app.bsky.embed.images',
+                  images,
+                };
+              }
+            }
+          }
+          const res = await agent.post(record);
+          const id = encodeAtprotoID(res.uri);
+          for (let i = 0; i < 10; i++) {
+            try {
+              return await statusAPI(id).fetch();
+            } catch (e) {
+              await wait(500);
+            }
+          }
+          const profile = await agent.getProfile({ actor: agent.did });
+          return postToStatus(
+            {
+              uri: res.uri,
+              cid: res.cid,
+              author: profile.data,
+              record,
+              reply: record.reply,
+            },
+            agent,
+          );
+        },
+      },
+      polls: {
+        $select(id) {
+          return {
+            async fetch() {
+              throw new Error('Bluesky polls are not supported');
+            },
+            votes: {
+              async create() {
+                throw new Error('Bluesky polls are not supported');
+              },
+            },
+          };
+        },
+      },
+      annualReports: {
+        $select(year) {
+          return {
+            async fetch() {
+              return {
+                accounts: [],
+                statuses: [],
+                annualReports: [{ year, data: {} }],
+              };
+            },
+          };
+        },
+      },
+      media: {
+        async create({ file, description } = {}) {
+          return createMediaUpload({
+            agent,
+            uploadedMedia,
+            file,
+            description,
+          });
+        },
+      },
+      instance: {
+        async fetch() {
+          return atprotoInstanceInfo();
+        },
+      },
+      preferences: {
+        async fetch() {
+          return {};
+        },
+      },
+      reports: {
+        async create({ accountId, statusIds, category, comment } = {}) {
+          let subject = {
+            $type: 'com.atproto.admin.defs#repoRef',
+            did: normalizeActor(accountId),
+          };
+          if (statusIds?.length) {
+            const status = await statusAPI(statusIds[0]).fetch();
+            subject = {
+              $type: 'com.atproto.repo.strongRef',
+              uri: status.uri,
+              cid: status._atproto.cid,
+            };
+          }
+          return agent.com.atproto.moderation.createReport({
+            reasonType:
+              category === 'spam'
+                ? 'com.atproto.moderation.defs#reasonSpam'
+                : 'com.atproto.moderation.defs#reasonViolation',
+            reason: comment,
+            subject,
+          });
+        },
+      },
+    },
+    v2: {
+      media: {
+        async create(params = {}) {
+          return this._create(params);
+        },
+        async _create({ file, description } = {}) {
+          return createMediaUpload({
+            agent,
+            uploadedMedia,
+            file,
+            description,
+          });
+        },
+      },
+      instance: {
+        async fetch() {
+          return atprotoInstanceInfo();
+        },
+      },
+      notifications: {
+        list(opts = {}) {
+          return makeCollection((cursor) =>
+            fetchNotifications(opts, cursor).then(toGroupedNotificationsPage),
+          );
+        },
+        policy: {
+          async fetch() {
+            return {};
+          },
+          async update(policy = {}) {
+            return policy;
+          },
+        },
+      },
+      filters: {
+        async list() {
+          return [];
+        },
+        async create() {
+          throw new Error('Bluesky filters are not supported');
+        },
+        $select() {
+          return {
+            async update() {
+              throw new Error('Bluesky filters are not supported');
+            },
+            async remove() {
+              throw new Error('Bluesky filters are not supported');
+            },
+          };
+        },
+      },
+      search: {
+        async fetch(params = {}) {
+          return this.list(params);
+        },
+        async list({ q = '', type, limit = 20 } = {}) {
+          const wanted = type ? [type] : ['accounts', 'statuses', 'hashtags'];
+          const results = {
+            accounts: [],
+            statuses: [],
+            hashtags: [],
+          };
+
+          if (wanted.includes('accounts')) {
+            const res = await agent.searchActors({
+              term: q,
+              limit,
+            });
+            results.accounts = res.data.actors.map(actorToAccount);
+          }
+
+          if (wanted.includes('statuses')) {
+            const res = await agent.app.bsky.feed.searchPosts({
+              q,
+              limit,
+            });
+            results.statuses = res.data.posts.map((post) =>
+              postToStatus(post, agent),
+            );
+          }
+
+          if (wanted.includes('hashtags')) {
+            const tag = q.replace(/^#/, '').trim();
+            results.hashtags = tag
+              ? [
+                  {
+                    name: tag,
+                    url: `/t/${encodeURIComponent(tag)}`,
+                    history: [],
+                  },
+                ]
+              : [];
+          }
+
+          return results;
+        },
+      },
+    },
+  };
+}
+
+export function atprotoInstanceInfo() {
+  return {
+    uri: BSKY_INSTANCE,
+    domain: BSKY_INSTANCE,
+    title: 'Bluesky',
+    version: '4.4.0 (compatible; Bluesky ATProto)',
+    sourceUrl: 'https://github.com/bluesky-social/social-app',
+    configuration: {
+      statuses: {
+        maxCharacters: 300,
+        maxMediaAttachments: 4,
+      },
+      mediaAttachments: {
+        supportedMimeTypes: [
+          'image/jpeg',
+          'image/png',
+          'image/webp',
+          'image/gif',
+          'video/mp4',
+        ],
+        imageSizeLimit: 1_000_000,
+        videoSizeLimit: 100_000_000,
+        descriptionLimit: 1_000,
+      },
+      polls: {
+        maxOptions: 0,
+      },
+    },
+    apiVersions: { mastodon: 7 },
+  };
+}
+
+export async function loginAtproto({
+  identifier,
+  password,
+  service = BSKY_PDS,
+}) {
+  const agent = new BskyAgent({ service });
+  await agent.login({ identifier, password });
+  const profile = await agent.getProfile({ actor: agent.did });
+  return {
+    agent,
+    account: actorToAccount(profile.data),
+    session: agent.session,
+    service,
+  };
+}
+
+export function createPublicAtprotoClient() {
+  return createAtprotoClient({ service: BSKY_APPVIEW });
+}

--- a/src/utils/atproto-route.js
+++ b/src/utils/atproto-route.js
@@ -1,0 +1,7 @@
+export function encodeAtprotoID(id) {
+  return encodeURIComponent(id);
+}
+
+export function decodeAtprotoID(id) {
+  return decodeURIComponent(id);
+}

--- a/src/utils/lists.js
+++ b/src/utils/lists.js
@@ -5,6 +5,17 @@ import store from './store';
 const FETCH_MAX_AGE = 1000 * 60; // 1 minute
 const MAX_AGE = 24 * 60 * 60 * 1000; // 1 day
 
+export function isFeedList(list) {
+  return list?._atproto?.type === 'feed';
+}
+
+export function splitListsAndFeeds(lists = []) {
+  return {
+    lists: lists.filter((list) => !isFeedList(list)),
+    feeds: lists.filter(isFeedList),
+  };
+}
+
 export const fetchLists = pmem(
   async () => {
     const { masto } = api();
@@ -41,6 +52,11 @@ export async function getLists() {
   } catch (e) {
     return [];
   }
+}
+
+export async function getUserLists() {
+  const lists = await getLists();
+  return splitListsAndFeeds(lists).lists;
 }
 
 export const fetchList = pmem(

--- a/src/utils/quote-utils.js
+++ b/src/utils/quote-utils.js
@@ -1,6 +1,7 @@
-import { getAPIVersions } from './store-utils';
+import { getAPIVersions, getCurrentInstance } from './store-utils';
 
 export function supportsNativeQuote() {
+  if (getCurrentInstance()?.domain === 'bsky.social') return true;
   return getAPIVersions()?.mastodon >= 7;
 }
 

--- a/src/utils/states.js
+++ b/src/utils/states.js
@@ -97,11 +97,10 @@ export function initStates() {
   states.shortcuts = store.account.get('shortcuts') ?? [];
   states.settings.autoRefresh =
     store.account.get('settings-autoRefresh') ?? false;
+  const shortcutsViewMode = store.account.get('settings-shortcutsViewMode');
   states.settings.shortcutsViewMode =
-    store.account.get('settings-shortcutsViewMode') ?? null;
-  if (store.account.get('settings-shortcutsColumnsMode')) {
-    states.settings.shortcutsColumnsMode = true;
-  }
+    shortcutsViewMode === 'multi-column' ? null : (shortcutsViewMode ?? null);
+  states.settings.shortcutsColumnsMode = false;
   states.settings.boostsCarousel =
     store.account.get('settings-boostsCarousel') ?? true;
   states.settings.contentTranslation =
@@ -135,7 +134,10 @@ subscribe(states, (changes) => {
       store.account.set('settings-boostsCarousel', !!value);
     }
     if (path.join('.') === 'settings.shortcutsViewMode') {
-      store.account.set('settings-shortcutsViewMode', value);
+      store.account.set(
+        'settings-shortcutsViewMode',
+        value === 'multi-column' ? null : value,
+      );
     }
     if (path.join('.') === 'settings.contentTranslation') {
       store.account.set('settings-contentTranslation', !!value);

--- a/src/utils/store-utils.js
+++ b/src/utils/store-utils.js
@@ -65,6 +65,9 @@ export const getCurrentAccID = mem(getCurrentAccountID, {
 export function setCurrentAccountID(id) {
   getCurrentAccID.cache.clear();
   try {
+    getCurrentAcc.cache.clear();
+  } catch (e) {}
+  try {
     store.session.set('currentAccount', id);
   } catch (e) {}
   if (standaloneMQ?.matches) {
@@ -142,6 +145,7 @@ export function getCurrentInstance() {
   if (currentInstance) return currentInstance;
   try {
     const account = getCurrentAccount();
+    if (!account) return {};
     const instances = store.local.getJSON('instances');
     const instance = account.instanceURL.toLowerCase();
     return (currentInstance = instances[instance]);
@@ -160,6 +164,7 @@ export function getCurrentNodeInfo() {
   if (currentNodeInfo) return currentNodeInfo;
   try {
     const account = getCurrentAccount();
+    if (!account) return {};
     const nodeInfos = store.local.getJSON('nodeInfos') || {};
     const instanceURL = account.instanceURL.toLowerCase();
     return (currentNodeInfo = nodeInfos[instanceURL] || {});

--- a/src/utils/store.js
+++ b/src/utils/store.js
@@ -141,7 +141,7 @@ const sessionCookie = {
 const account = {
   get: (key) => {
     try {
-      return local.getJSON(key)[getCurrentAccountNS()];
+      return local.getJSON(key)?.[getCurrentAccountNS()] ?? null;
     } catch (e) {
       console.warn(e);
       return null;

--- a/src/utils/supports.js
+++ b/src/utils/supports.js
@@ -29,6 +29,15 @@ const platformFeatures = {
 };
 
 const supportsCache = {};
+const bskyUnsupportedFeatures = new Set([
+  '@mastodon/filters',
+  '@mastodon/endorsements',
+  '@mastodon/pinned-posts',
+  '@mastodon/post-edit',
+  '@mastodon/profile-private-note',
+  '@mastodon/trending-hashtags',
+  '@mastodon/trending-links',
+]);
 
 const semverExtract = /^\d+\.\d+(\.\d+)?/;
 const atSoftwareSlashMatch = /^@([a-z]+)\//i;
@@ -37,6 +46,10 @@ function supports(feature) {
   try {
     let { version, domain } = getCurrentInstance();
     let softwareName = getCurrentNodeInfo()?.software?.name || 'mastodon';
+
+    if (domain === 'bsky.social' && bskyUnsupportedFeatures.has(feature)) {
+      return false;
+    }
 
     if (softwareName === 'hometown') {
       // Hometown is a Mastodon fork and inherits its features

--- a/vite.config.js
+++ b/vite.config.js
@@ -25,6 +25,7 @@ const {
   PHANPY_DISALLOW_ROBOTS: DISALLOW_ROBOTS,
   PHANPY_DEV,
 } = loadEnv('production', process.cwd(), allowedEnvPrefixes);
+const DEV_PORT = Number(process.env.PORT || process.env.VITE_PORT) || undefined;
 
 const now = new Date();
 let commitHash;
@@ -78,6 +79,7 @@ export default defineConfig({
   },
   server: {
     host: true,
+    port: DEV_PORT,
     watch: {
       awaitWriteFinish: {
         pollInterval: 1000,
@@ -271,7 +273,7 @@ export default defineConfig({
         injectionPoint: undefined,
       },
       devOptions: {
-        enabled: NODE_ENV === 'development',
+        enabled: false,
         type: 'module',
       },
     }),


### PR DESCRIPTION
## Summary

- add Bluesky/ATProto login and adapter plumbing
- render ATProto quoted posts, including quote details and compose preview behavior
- separate Lists and Feeds in navigation and picker UI
- make feed and Following selections replace Home and persist as the default timeline
- disable multi-column navigation paths for now

## Validation

- npm run build
- PORT=5173 npm test -- tests/logged-out-view.spec.js
- logged-in browser check with .secrets/phanpy-atproto-test.env on local dev server
