### PR TITLE
Add jxl support where image formats are found

### DIFF
--- a/src/components/edit-profile-sheet.jsx
+++ b/src/components/edit-profile-sheet.jsx
@@ -27,6 +27,7 @@ const SUPPORTED_IMAGE_FORMATS = [
   'image/png',
   'image/gif',
   'image/webp',
+  'image/jxl',
 ];
 const SUPPORTED_IMAGE_FORMATS_STR = SUPPORTED_IMAGE_FORMATS.join(',');
 

--- a/src/components/media-attachment.jsx
+++ b/src/components/media-attachment.jsx
@@ -445,7 +445,7 @@ function MediaAttachment({
                 {descTextarea}
                 <footer>
                   {suffixType === 'image' &&
-                    /^(png|jpe?g|gif|webp)$/i.test(subtype) &&
+                    /^(png|jpe?g|gif|webp|jxl)$/i.test(subtype) &&
                     !!states.settings.mediaAltGenerator &&
                     !!IMG_ALT_API_URL && (
                       <Menu2

--- a/src/locales/en.po
+++ b/src/locales/en.po
@@ -183,7 +183,7 @@ msgid "View profile header"
 msgstr "View profile header"
 
 #: src/components/account-info.jsx:714
-#: src/components/edit-profile-sheet.jsx:267
+#: src/components/edit-profile-sheet.jsx:268
 #: src/components/related-actions.jsx:881
 msgid "Edit profile"
 msgstr ""
@@ -274,7 +274,7 @@ msgstr "View post stats"
 #: src/components/compose.jsx:1127
 #: src/components/custom-emojis-modal.jsx:282
 #: src/components/drafts.jsx:57
-#: src/components/edit-profile-sheet.jsx:262
+#: src/components/edit-profile-sheet.jsx:263
 #: src/components/embed-modal.jsx:13
 #: src/components/generic-accounts.jsx:151
 #: src/components/gif-picker-modal.jsx:71
@@ -531,7 +531,7 @@ msgstr ""
 
 #: src/components/compose.jsx:1546
 #: src/components/compose.jsx:1692
-#: src/components/edit-profile-sheet.jsx:692
+#: src/components/edit-profile-sheet.jsx:693
 #: src/components/import-accounts-selection.jsx:175
 #: src/components/open-link-sheet.jsx:74
 #: src/components/private-note-sheet.jsx:92
@@ -700,8 +700,8 @@ msgid "Error deleting draft! Please try again."
 msgstr ""
 
 #: src/components/drafts.jsx:126
-#: src/components/edit-profile-sheet.jsx:108
-#: src/components/edit-profile-sheet.jsx:120
+#: src/components/edit-profile-sheet.jsx:109
+#: src/components/edit-profile-sheet.jsx:121
 #: src/components/list-add-edit.jsx:188
 #: src/components/status.jsx:1685
 #: src/pages/filters.jsx:605
@@ -771,7 +771,7 @@ msgstr ""
 msgid "Exit"
 msgstr "Exit"
 
-#: src/components/edit-profile-sheet.jsx:87
+#: src/components/edit-profile-sheet.jsx:88
 #: src/components/media-alt-modal.jsx:55
 #: src/components/media-attachment.jsx:465
 #: src/components/media-modal.jsx:398
@@ -792,100 +792,100 @@ msgstr "Exit"
 msgid "More"
 msgstr ""
 
-#: src/components/edit-profile-sheet.jsx:94
+#: src/components/edit-profile-sheet.jsx:95
 #: src/components/shortcuts-settings.jsx:368
 #: src/pages/accounts.jsx:219
 msgid "Move up"
 msgstr ""
 
-#: src/components/edit-profile-sheet.jsx:100
+#: src/components/edit-profile-sheet.jsx:101
 #: src/components/shortcuts-settings.jsx:384
 #: src/pages/accounts.jsx:234
 msgid "Move down"
 msgstr ""
 
-#: src/components/edit-profile-sheet.jsx:115
+#: src/components/edit-profile-sheet.jsx:116
 msgid "Delete this field?"
 msgstr "Delete this field?"
 
-#: src/components/edit-profile-sheet.jsx:225
+#: src/components/edit-profile-sheet.jsx:226
 msgid "Unable to remove profile picture."
 msgstr "Unable to remove profile picture."
 
-#: src/components/edit-profile-sheet.jsx:245
+#: src/components/edit-profile-sheet.jsx:246
 msgid "Unable to remove header picture."
 msgstr "Unable to remove header picture."
 
-#: src/components/edit-profile-sheet.jsx:296
+#: src/components/edit-profile-sheet.jsx:297
 msgid "Profile and header pictures have no descriptions. Continue?"
 msgstr "Profile and header pictures have no descriptions. Continue?"
 
-#: src/components/edit-profile-sheet.jsx:303
+#: src/components/edit-profile-sheet.jsx:304
 msgid "Profile picture has no description. Continue?"
 msgstr "Profile picture has no description. Continue?"
 
-#: src/components/edit-profile-sheet.jsx:309
+#: src/components/edit-profile-sheet.jsx:310
 msgid "Header picture has no description. Continue?"
 msgstr "Header picture has no description. Continue?"
 
-#: src/components/edit-profile-sheet.jsx:371
+#: src/components/edit-profile-sheet.jsx:372
 msgid "Unable to update profile."
 msgstr "Unable to update profile."
 
-#: src/components/edit-profile-sheet.jsx:389
+#: src/components/edit-profile-sheet.jsx:390
 msgid "Header picture"
 msgstr "Header picture"
 
-#: src/components/edit-profile-sheet.jsx:444
-#: src/components/edit-profile-sheet.jsx:536
+#: src/components/edit-profile-sheet.jsx:445
+#: src/components/edit-profile-sheet.jsx:537
 #: src/components/media-attachment.jsx:242
 msgid "Image description"
 msgstr "Image description"
 
-#: src/components/edit-profile-sheet.jsx:462
+#: src/components/edit-profile-sheet.jsx:463
 msgid "Remove header picture?"
 msgstr "Remove header picture?"
 
-#: src/components/edit-profile-sheet.jsx:473
-#: src/components/edit-profile-sheet.jsx:565
+#: src/components/edit-profile-sheet.jsx:474
+#: src/components/edit-profile-sheet.jsx:566
 #: src/pages/list.jsx:388
 msgid "Remove…"
 msgstr ""
 
-#: src/components/edit-profile-sheet.jsx:481
+#: src/components/edit-profile-sheet.jsx:482
 msgid "Profile picture"
 msgstr "Profile picture"
 
-#: src/components/edit-profile-sheet.jsx:554
+#: src/components/edit-profile-sheet.jsx:555
 msgid "Remove profile picture?"
 msgstr "Remove profile picture?"
 
-#: src/components/edit-profile-sheet.jsx:574
+#: src/components/edit-profile-sheet.jsx:575
 #: src/components/list-add-edit.jsx:106
 msgid "Name"
 msgstr ""
 
-#: src/components/edit-profile-sheet.jsx:590
+#: src/components/edit-profile-sheet.jsx:591
 msgid "Bio"
 msgstr ""
 
-#: src/components/edit-profile-sheet.jsx:607
+#: src/components/edit-profile-sheet.jsx:608
 msgid "Custom fields"
 msgstr "Custom fields"
 
-#: src/components/edit-profile-sheet.jsx:613
+#: src/components/edit-profile-sheet.jsx:614
 msgid "Label"
 msgstr ""
 
-#: src/components/edit-profile-sheet.jsx:616
+#: src/components/edit-profile-sheet.jsx:617
 msgid "Content"
 msgstr ""
 
-#: src/components/edit-profile-sheet.jsx:678
+#: src/components/edit-profile-sheet.jsx:679
 msgid "Add field"
 msgstr "Add field"
 
-#: src/components/edit-profile-sheet.jsx:695
+#: src/components/edit-profile-sheet.jsx:696
 #: src/components/list-add-edit.jsx:152
 #: src/components/quote-settings-sheet.jsx:92
 #: src/components/shortcuts-settings.jsx:732


### PR DESCRIPTION
After installing FF152 and enabling the jpeg-xl flag, I tried uploading a .jxl image to my GTS server, via phanpy.

I've made the changes to enable support, by doing a search for 'png'.

Thanks for the epic fedi client btw!