### PR TITLE
Fix missing native image context menu in media modal

### DIFF
--- a/src/components/media.jsx
+++ b/src/components/media.jsx
@@ -434,8 +434,13 @@ function Media({
                   data-orientation={orientation}
                   loading="eager"
                   decoding="sync"
+                  draggable={false}
                   style={{
                     'view-transition-name': mediaVTN,
+                    // react-zoom-pan-pinch disables pointer events on imgs,
+                    // breaking the native image context menu (Copy Image, etc.);
+                    // native dragging stays off via draggable={false}
+                    pointerEvents: 'auto',
                   }}
                   onLoad={(e) => {
                     const el = e.target;

--- a/src/locales/en.po
+++ b/src/locales/en.po
@@ -1548,7 +1548,7 @@ msgstr ""
 msgid "Filtered"
 msgstr ""
 
-#: src/components/media.jsx:562
+#: src/components/media.jsx:567
 msgid "Open file"
 msgstr "Open file"
 


### PR DESCRIPTION
Right-clicking an image in the full-screen media modal shows the browser's generic page context menu (Back / Reload / Save Page As…) instead of the image context menu — **Copy Image**, **Copy Image Link** and **Save Image As…** are unavailable.

## Root cause

`react-zoom-pan-pinch`, which powers pinch-zoom in the modal, ships this rule in its bundled stylesheet:

```css
.content img {
  pointer-events: none;
}
```

so the `<img>` inside `TransformComponent` can never be a hit-test target. Right-clicks land on the `react-transform-component` wrapper div, and the browser has no image element to build the image context menu for. Verified on dev.phanpy.social (`2026.07.20.57870e3`): `document.elementFromPoint()` at the image's center returns the wrapper div, and the img's computed `pointer-events` is `none`.

## Fix

Set inline `pointerEvents: 'auto'` and `draggable={false}` on the modal `<img>` in `src/components/media.jsx`.

The inline style overrides the library's stylesheet, and `draggable={false}` keeps native image dragging off — which is what the library rule was guarding against, since a drag ghost would interfere with panning.

## Verified

- Right-click on the modal image now targets the `<img>` → native image context menu with Copy Image etc.
- Double-click zoom still works (transform scale changes)
- Panning while zoomed still works — pointer events bubble up to the library's wrapper, and no native drag ghost appears
- Tested on macOS against mastodon.social in Chromium and in Zen Browser 1.21.9b (Firefox 153.0, aarch64)

## Notes

- The commit also carries a one-line `en.po` reference shift regenerated from the `media.jsx` edit.
- iOS long-press is likely still suppressed: the library also sets `-webkit-touch-callout: none` on its wrapper. Left out of scope here — desktop right-click is the common case — but could be a follow-up.
