### PR TITLE
Fix search suggestions not clickable when the press is slow

### DIFF
--- a/src/components/search-form.jsx
+++ b/src/components/search-form.jsx
@@ -327,7 +327,13 @@ const SearchForm = forwardRef((props, ref) => {
           }
         }}
       />
-      <div class="search-popover" hidden={!searchMenuOpen}>
+      <div
+        class="search-popover"
+        hidden={!searchMenuOpen}
+        // Keep focus on the input so the popover is not hidden by the blur
+        // handler before the pointer is released on an item
+        onMouseDown={(e) => e.preventDefault()}
+      >
         {/* Search History - show when no query */}
         {!query && searchHistory.length > 0 && (
           <div class="search-popover-recent-searches">

--- a/src/locales/en.po
+++ b/src/locales/en.po
@@ -2173,7 +2173,7 @@ msgid "Cleared recent searches"
 msgstr "Cleared recent searches"
 
 #: src/components/recent-searches.jsx:49
-#: src/components/search-form.jsx:336
+#: src/components/search-form.jsx:342
 msgid "Recent searches"
 msgstr "Recent searches"
 
@@ -2546,7 +2546,7 @@ msgstr ""
 msgid "Look up <0>{query}</0>"
 msgstr ""
 
-#: src/components/search-form.jsx:369
+#: src/components/search-form.jsx:375
 #: src/pages/home.jsx:260
 msgid "See all"
 msgstr ""

--- a/tests/search-suggestions.spec.js
+++ b/tests/search-suggestions.spec.js
@@ -1,0 +1,33 @@
+// @ts-check
+import { expect, test } from '@playwright/test';
+
+test.setTimeout(120000);
+
+test('search suggestion stays clickable while the pointer is held down', async ({
+  page,
+}) => {
+  await page.goto('/#/search');
+  await page.waitForSelector('input[name="q"]', { timeout: 60000 });
+
+  const input = page.locator('input[name="q"]:visible').first();
+  await input.click();
+  await input.fill('hello');
+
+  const popover = page.locator('.search-popover').first();
+  const suggestion = page
+    .locator('.search-popover:not([hidden]) .search-popover-item')
+    .first();
+  await expect(suggestion).toBeVisible();
+
+  const box = await suggestion.boundingBox();
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.down();
+
+  // The popover must survive the press. It used to hide 100ms after the input
+  // blurred, so a slower click released over a hidden element and did nothing.
+  await page.waitForTimeout(300);
+  await expect(popover).not.toHaveAttribute('hidden', /.*/);
+
+  await page.mouse.up();
+  await expect(page).toHaveURL(/q=hello/);
+});


### PR DESCRIPTION
Fixes #1576.

Clicking a search suggestion does nothing unless the press is quick. Pressing Enter always works, which matches the report.

The input's `onBlur` hides the popover 100ms later, and the popover is only `hidden`, not unmounted. Pressing a suggestion blurs the input on mousedown, so a press that lasts longer than 100ms leaves the popover `display: none` before mouseup, and no click event ever fires.

Preventing the default mousedown inside the popover keeps focus on the input, so it can't hide mid-press. The same `// autofocus` style inline comment convention already used in this file is kept.

### Testing

Added a Playwright test that holds the press for 300ms, asserts the popover is still open, and asserts navigation happens. It fails on `main` (popover has `hidden`) and passes with this change.

Full suite on Mobile Safari: 63 passed, 1 failed. The failure is `date-time-format.spec.js:176` (`en-SG` locale combination), which fails the same way with this change stashed, so it looks unrelated to this PR.